### PR TITLE
CRAYSAT-1460: Allow manipulating multiple playbooks at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0] - 2022-08-09
+
+### Added
+
+- Added functionality which allows the `--playbook` command line argument to be
+  used multiple times to specify multiple playbooks for the given product.
+  A separate layer will be targeted for each given playbook.
+
 ## [3.1.1] - 2022-06-24
 
 ### Changed

--- a/cfs_config_util/parser.py
+++ b/cfs_config_util/parser.py
@@ -113,10 +113,12 @@ def add_layer_content_options(parser):
     )
 
     repo_group.add_argument(
-        '--playbook',
+        '--playbook', action='append', dest='playbooks', metavar='playbook',
         help='The name of the playbook for the layer being targeted. If not '
              'specified, then no playbook will be specified in the layer, '
-             'which means CFS will use its internal default.'
+             'which means CFS will use its internal default. If specified '
+             'multiple times, then a separate layer will be targeted for each '
+             'given playbook.'
     )
 
     repo_group.add_argument(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,99 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Tests for the cfs_config_util.main module.
+"""
+
+from argparse import Namespace
+import unittest
+from unittest.mock import patch
+
+
+from cfs_config_util.bin.main import construct_layers
+
+
+class TestConstructLayers(unittest.TestCase):
+    """Tests for the construct_layers() function"""
+
+    def setUp(self):
+        self.layer_name = 'test_layer'
+        self.playbook_name = 'test.yml'
+        self.product_name = 'product'
+
+        self.args = Namespace(
+            layer_name=self.layer_name,
+            playbooks=[self.playbook_name],
+            product=self.product_name,
+            git_commit=None,
+            git_branch=None,
+        )
+
+        patcher = patch('cfs_config_util.bin.main.CFSConfigurationLayer')
+        self.mock_cfs_configuration_layer = patcher.start()
+
+    def tearDown(self):
+        patch.stopall()
+
+    def test_single_layer_constructed(self):
+        """Test constructing a single layer for a product"""
+        construct_layers(self.args)
+        self.mock_cfs_configuration_layer.from_product_catalog.assert_called_once_with(
+            self.product_name,
+            product_version=None,
+            name=self.layer_name,
+            playbook=self.playbook_name,
+            commit=None,
+            branch=None,
+        )
+
+    def test_single_default_layer_constructed_for_no_playbook(self):
+        """Test that a default layer is constructed when no playbook is given"""
+        self.args.playbooks = None
+        construct_layers(self.args)
+        self.mock_cfs_configuration_layer.from_product_catalog.assert_called_once_with(
+            self.product_name,
+            product_version=None,
+            name=self.layer_name,
+            playbook=None,
+            commit=None,
+            branch=None,
+        )
+
+    def test_multiple_playbook_layers_constructed(self):
+        """Test constructing multiple layers for a product with multiple playbooks"""
+        additional_playbook = 'additional.yml'
+        playbooks = [self.playbook_name, additional_playbook]
+        self.args.playbooks = playbooks
+
+        construct_layers(self.args)
+
+        for playbook in playbooks:
+            self.mock_cfs_configuration_layer.from_product_catalog.assert_any_call(
+                self.product_name,
+                product_version=None,
+                name=self.layer_name,
+                playbook=playbook,
+                commit=None,
+                branch=None,
+            )


### PR DESCRIPTION
## Summary and Scope

This change adds functionality which allows the `--playbook` option to
be specified multiple times. If multiple `--playbook` options are given,
then a separate layer will be created (or removed) for each given
playbook. The behavior when at most one `--playbook` is given remains
unchanged.

## Issues and Related PRs

* Resolves [CRAYSAT-1460](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1460)

## Testing

### Tested on:

  * `groot`

### Test description:

Run unit tests. Create a new configuration on based on the
`ncn-personalization` configuration with multiple COS layers with
different playbooks as specified in the Upgrade and Install COS guide.
Ensure that the proper layers were created. Test creating a new COS
layer without a playbook. Test removing a single COS layer.

## Risks and Mitigations

None.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

