### PR TITLE
CRAYSAT-1459: Make --base* args optional, fix help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.0] - 2022-08-17
+
+### Changed
+- The `--base-config`, `--base-file`, and `--base-query` options are no longer
+  required. If they are not supplied, then `cfs-config-util` will start from an
+  empty configuration, but overwriting existing configurations will be disabled.
+
+### Fixed
+- The `--help` text for `--base-config`, `--base-file`, and `--base-query` have
+  been corrected. If a non-existent CFS configuration is given with
+  `--base-config` or a non-existent file is given with `--base-file`, then an
+  error will be displayed. Similarly, if no CFS configurations are found with
+  `--base-query`, then an error will be displayed.
+
 ## [3.2.0] - 2022-08-09
 
 ### Added

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -27,10 +27,14 @@ Tests for the cfs_config_util.main module.
 
 from argparse import Namespace
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 
-from cfs_config_util.bin.main import construct_layers
+from cfs_config_util.cfs import CFSConfiguration
+from cfs_config_util.bin.main import (
+    construct_layers,
+    save_cfs_configuration,
+)
 
 
 class TestConstructLayers(unittest.TestCase):
@@ -97,3 +101,47 @@ class TestConstructLayers(unittest.TestCase):
                 commit=None,
                 branch=None,
             )
+
+
+class TestSaveCFSConfigs(unittest.TestCase):
+    """Tests for the save_cfs_configurations() function"""
+    def setUp(self):
+        self.product_name = 'testproduct'
+        self.config_name = 'test-config'
+        self.config_path = 'test_config.json'
+
+        self.base_args = Namespace(
+            product=self.product_name,
+            base_config=None,
+            base_file=None,
+            base_query=None,
+            save=None,
+            save_suffix=None,
+            save_to_file=None,
+            save_to_cfs=None,
+        )
+
+        self.mock_cfs_config = MagicMock(autospec=CFSConfiguration)
+
+    def tearDown(self):
+        patch.stopall()
+
+    def test_save_to_cfs_no_overwrite_when_no_base(self):
+        """Test that overwriting CFS config is disabled when no base is given"""
+        self.base_args.save_to_cfs = self.config_name
+
+        save_cfs_configuration(self.base_args, self.mock_cfs_config)
+        self.mock_cfs_config.save_to_cfs.assert_called_once_with(
+            self.config_name,
+            overwrite=False
+        )
+
+    def test_save_to_file_no_overwrite_when_no_base(self):
+        """Test that overwriting file is disabled when no base is given"""
+        self.base_args.save_to_file = self.config_path
+
+        save_cfs_configuration(self.base_args, self.mock_cfs_config)
+        self.mock_cfs_config.save_to_file.assert_called_once_with(
+            self.config_path,
+            overwrite=False
+        )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -79,13 +79,16 @@ class TestParseAndCheckArgs(unittest.TestCase):
     def test_parse_and_check_combinations(self):
         """Test parsing args when given various combinations of args."""
         for layer_args, base_args, save_args in itertools.product(self.layer_alternatives,
-                                                                  self.base_alternatives,
+                                                                  self.base_alternatives + [],
                                                                   self.save_alternatives):
             full_args = layer_args + base_args + save_args
             with self.subTest(full_args=full_args):
-                # If using --base-query, then must use --save or --save-suffix
-                valid_combo = (base_args != self.base_query_args
-                               or save_args in [self.save_args, self.save_suffix_args])
+                # If using --base-query, then must use --save or --save-suffix.
+                # If not using any --base*, cannot use --save or --save-suffix.
+                valid_combo = (not (base_args == self.base_query_args
+                                    and save_args in [self.save_to_cfs_args, self.save_to_file_args])
+                               and (base_args or save_args not in [self.save_args, self.save_suffix_args]))
+
                 parsed_args = self.parser.parse_args(full_args)
                 if valid_combo:
                     check_args(parsed_args)
@@ -119,11 +122,6 @@ class TestParseAndCheckArgs(unittest.TestCase):
     def test_missing_layer_args(self):
         """Test parsing when missing an arg that defines the layer."""
         self.assert_parse_error(self.base_config_args + self.save_args,
-                                self.missing_args_msg)
-
-    def test_missing_base_args(self):
-        """Test parsing when missing an argument specifying the base configuration or file."""
-        self.assert_parse_error(self.product_layer_args + self.save_args,
                                 self.missing_args_msg)
 
     def test_missing_save_args(self):


### PR DESCRIPTION
## Summary and Scope

This change fixes the help text for the --base* options regarding their
behavior when no valid base is given. The text specifying that
cfs-config-util will start with an empty configuration has been deleted.
It is left implicit that non-existent configurations and files will
raise errors.

This change also modifies the behavior of cfs-config-util when no
--base* option is given. When no base is given, cfs-config-util will
start from an empty configuration with no layers. --save and
--save-suffix may not be used if no --base* is given. To avoid
clobbering existing configurations, --save-to-cfs and --save-to-file
will not work if an existing configuration or filename is given.


## Issues and Related PRs

* Resolves [CRAYSAT-1459](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1459)

## Testing

### Tested on:

  * `groot`

### Test description:

Run unit tests. On groot, manually do a sanity check by running
cfs-config-util commands inside container with various combinations of
options: without --base-* and with --save-* options, both once and
multiple times to check overwrite behavior; check with --base-* and with
--save-* to check for regressions; Check with non-existent --base-*
options.

## Risks and Mitigations

Creating empty configurations could overwrite existing configurations. Feature was designed to prevent data loss and is tested.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable