### PR TITLE
CRAYSAT-1750: Update PyYAML to 6.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.2] - 2023-08-02
+
+### Changed
+- Updated PyYAML to version 6.0.1, cray-product-catalog to 1.8.12, and
+  csm-api-client to 1.1.5 in order to fix a build problem with earlier versions
+  of PyYAML.
+
 ## [4.0.1] - 2023-01-13
 
 ### Security

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -5,8 +5,8 @@ cachetools==5.2.0
 certifi==2022.12.7
 charset-normalizer==2.1.1
 coverage==6.0.2
-cray-product-catalog==1.6.0
-csm-api-client==1.0.0
+cray-product-catalog==1.8.12
+csm-api-client==1.1.5
 google-auth==2.11.0
 idna==3.4
 inflect==6.0.0
@@ -21,7 +21,7 @@ pycodestyle==2.8.0
 pydantic==1.10.2
 pyrsistent==0.18.1
 python-dateutil==2.8.2
-PyYAML==5.4.1
+PyYAML==6.0.1
 requests==2.28.1
 requests-oauthlib==1.3.1
 rsa==4.9

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -4,8 +4,8 @@ botocore==1.27.74
 cachetools==5.2.0
 certifi==2022.12.7
 charset-normalizer==2.1.1
-cray-product-catalog==1.6.0
-csm-api-client==1.0.0
+cray-product-catalog==1.8.12
+csm-api-client==1.1.5
 google-auth==2.11.0
 idna==3.4
 inflect==6.0.0
@@ -18,7 +18,7 @@ pyasn1-modules==0.2.8
 pydantic==1.10.2
 pyrsistent==0.18.1
 python-dateutil==2.8.2
-PyYAML==5.4.1
+PyYAML==6.0.1
 requests==2.28.1
 requests-oauthlib==1.3.1
 rsa==4.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,2 @@
 cray-product-catalog >= 1.6.0
 csm-api-client >= 1.0, < 2.0
-kubernetes
-PyYAML < 6.0.0
-requests < 3.0
-requests-oauthlib


### PR DESCRIPTION
## Summary and Scope
Update the version of PyYAML to 6.0.1 to resolve a build problem. This problem was due to an incompatibility introduced in Cython 3.0, which PyYAML addressed by pinning their builds to `Cython<3.0` for the time being.

Update the versions of `cray-product-catalog` and `csm-api-client` to newer versions which add PyYAML 6.0 compatibility.

Also remove `PyYAML`, `requests`, and `kubernetes` from the top-level requirements of this repository. Those are no longer direct dependencies of this repo since it uses the `csm-api-client` and `cray-product-catalog` libraries for access to the CSM APIs and Kubernetes now.

Since we don't use `PyYAML` directly, and the versions of our dependencies have been updated for compatibility with PyYAML 6.0, we don't have to worry about any incompatibilities with this code.

## Issues and Related PRs

* Resolves [CRAYSAT-1750](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1750)

## Testing

### Tested on:

  * Jenkins

### Test description:

Test that build works in Jenkins.

Tested on mug by defining wrapper functions from hpc-shastarelm-release and then executing those functions to modify a configuration from a file and from CFS. See [this gist](https://gist.github.com/haasken-hpe/85a9878983593ad1bac479a0273612d1) for detailed output.

## Risks and Mitigations

Pretty low risk. This just pulls in new versions of dependencies.

This code is also deprecated in favor of using `sat bootprep` as part of the IUF.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

