### PR TITLE
CASMINST-6597: Add component update options to cfs-config-util

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.0] - 2023-09-14
+
+### Changed
+- The main entry point now requires an action to be specified. This is either
+  `update-configs` or `update-components`. The `update-configs` action
+  implements all functionality which used to occur when no action was specified.
+
+### Added
+- Added a new `update-components` action which updates CFS components and waits
+  for them to be configured.
+- Added options to the `update-configs` action which allow for the CFS
+  configuration to be assigned to CFS components.
+- Added logic to the `update-configs` action which waits for CFS components
+  which have been affected by CFS configuration changes to become configured.
+
 ## [4.0.3] - 2023-08-04
 
 ### Security

--- a/cfs_config_util/bin/main.py
+++ b/cfs_config_util/bin/main.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -25,30 +25,16 @@
 Main entrypoint to CFS update utility
 """
 
-import argparse
-import json
 import logging
 
-from csm_api_client.service.cfs import (
-    CFSClient,
-    CFSConfiguration,
-    CFSConfigurationError,
-    CFSConfigurationLayer,
-)
-from csm_api_client.service.gateway import APIError
-from csm_api_client.service.hsm import HSMClient
-from csm_api_client.session import AdminSession
-
-from cfs_config_util.environment import (
-    API_CERT_VERIFY,
-    API_GW_HOST,
-)
 from cfs_config_util.parser import (
-    BASE_QUERY_OPTION,
-    base_given,
+    CANONICAL_UPDATE_CONFIGS_ACTION,
+    CANONICAL_UPDATE_COMPONENTS_ACTION,
     check_args,
     create_parser,
 )
+from cfs_config_util.update_components import do_update_components
+from cfs_config_util.update_configs import do_update_configs
 
 LOGGER = logging.getLogger(__name__)
 
@@ -72,160 +58,6 @@ def configure_logging():
     logger.setLevel(logging.INFO)
 
 
-def get_cfs_configurations(args, cfs_client, hsm_client):
-    """Get the CFSConfigurations from CFS or from a file.
-
-    Args:
-        args (argparse.Namespace): the parsed command-line args
-        cfs_client (csm_api_client.service.cfs.CFSClient): the CFS API client
-        hsm_client (cfs_config_util.apiclient.HSMClient): the HSM API client
-
-    Returns:
-        list of csm_api_client.service.cfs.CFSConfiguration: the CFS configurations
-            from CFS or loaded from a file. If a name of a CFS config or a file
-            name is given, the list will have only one element.
-
-    Raises:
-        CFSConfigurationError: if unable get the CFS configuration from the CFS
-            API or unable to load it from a file
-    """
-    if args.base_config is not None:
-        # Get the CFSConfiguration from the CFS API
-        try:
-            return [cfs_client.get_configuration(args.base_config)]
-        except APIError as err:
-            raise CFSConfigurationError(f'Could not retrieve configuration '
-                                        f'"{args.base_config}" from CFS: {err}')
-
-    elif args.base_query is not None:
-        # Protect against an empty query returning all components
-        if not args.base_query:
-            raise CFSConfigurationError(f'Query params specified by {BASE_QUERY_OPTION} '
-                                        f'must be non-empty.')
-        try:
-            query_params = {param: value for param, value in
-                            [query.split('=', maxsplit=1) for query in args.base_query.split(',')]}
-        except ValueError:
-            raise CFSConfigurationError(
-                f'Invalid query "{args.base_query}". Query string must consist '
-                f'of one or more comma-separated key=value pairs.'
-            )
-
-        try:
-            configs = cfs_client.get_configurations_for_components(hsm_client, **query_params)
-            if not configs:
-                raise CFSConfigurationError(
-                    f'No configurations were found matching the query "{args.base_query}".'
-                )
-            return configs
-        except APIError as err:
-            raise CFSConfigurationError(
-                f'Could not retrieve CFS configurations for HSM components '
-                f'matching the query "{args.base_query}": {err}'
-            )
-
-    else:
-        # args.base_file must have been specified, so load from a file
-        try:
-            with open(args.base_file, 'r') as f:
-                file_data = json.load(f)
-        except OSError as err:
-            raise CFSConfigurationError(f'Failed to open file {args.base_file}: {err}')
-        except json.decoder.JSONDecodeError as err:
-            raise CFSConfigurationError(f'Failed to parse JSON in file {args.base_file}: {err}')
-
-        return [CFSConfiguration(cfs_client, file_data)]
-
-
-def construct_layers(args):
-    """Construct a CFSConfigurationLayer which should be added or removed from a CFSConfiguration.
-
-    Args:
-        args (argparse.Namespace): the parsed command-line args
-
-    Returns:
-        List[CFSConfigurationLayer]: the layers that should be added or removed
-
-    Raises:
-        CFSConfigurationError: if unable to construct the requested layer
-    """
-    # These kwargs are common between both layers defined by clone URL and layers
-    # defined by product.
-    layers = []
-    playbooks = args.playbooks
-
-    # If the --playbook option is not supplied, then only create one layer with
-    # the default playbook. Passing `None` as the playbook argument to the
-    # layer creation methods achieves this.
-    if playbooks is None:
-        playbooks = [None]
-
-    for playbook in playbooks:
-        common_args = {
-            'name': args.layer_name,
-            'playbook': playbook,
-            'commit': args.git_commit,
-            'branch': args.git_branch
-        }
-        if args.product:
-            if ':' in args.product:
-                product_name, product_version = args.product.split(':', maxsplit=1)
-            else:
-                product_name = args.product
-                product_version = None
-            layers.append(
-                CFSConfigurationLayer.from_product_catalog(
-                    product_name, API_GW_HOST, product_version=product_version, **common_args)
-            )
-        else:
-            layers.append(
-                CFSConfigurationLayer.from_clone_url(args.clone_url, **common_args)
-            )
-    return layers
-
-
-def save_cfs_configuration(args, cfs_config):
-    """Save the CFSConfiguration to a file or to CFS per the command-line args.
-
-    Args:
-        args (argparse.Namespace): the parsed command-line args
-        cfs_config (csm_api_client.service.cfs.CFSConfiguration): the modified
-            CFS configuration to save
-
-    Returns:
-        None
-
-    Raises:
-        CFSConfigurationError: if unable to save the CFS configuration to CFS
-            or to a file.
-    """
-    if args.save:
-        if args.base_config or args.base_query:
-            # Overwrite the CFS configuration in CFS
-            cfs_config.save_to_cfs()
-        else:
-            # args.base_file; overwrite the file in place
-            cfs_config.save_to_file(args.base_file)
-
-    elif args.save_suffix:
-        if args.base_config or args.base_query:
-            cfs_config.save_to_cfs(f'{cfs_config.name}{args.save_suffix}')
-        else:
-            cfs_config.save_to_file(f'{args.base_file}{args.save_suffix}')
-
-    elif args.save_to_cfs:
-        cfs_config.save_to_cfs(
-            args.save_to_cfs,
-            overwrite=base_given(args)
-        )
-
-    elif args.save_to_file:
-        cfs_config.save_to_file(
-            args.save_to_file,
-            overwrite=base_given(args)
-        )
-
-
 def main():
     """Modify a CFS configuration and save it as specified by the command-line args.
 
@@ -245,48 +77,12 @@ def main():
         LOGGER.error(str(err))
         raise SystemExit(1)
 
-    session = AdminSession(API_GW_HOST, API_CERT_VERIFY)
-    hsm_client = HSMClient(session)
-    cfs_client = CFSClient(session)
+    LOGGER.debug(f'Received action "{args.action}" which corresponds to '
+                 f'canonical action "{args.canonical_action}".')
 
-    try:
-        if base_given(args):
-            base_configs = get_cfs_configurations(args, cfs_client, hsm_client)
-        else:
-            LOGGER.info('No base configuration given. Starting from empty configuration. '
-                        'Existing configurations will not be overwritten.')
-            base_configs = [CFSConfiguration.empty(cfs_client)]
-
-        layers = construct_layers(args)
-
-    except CFSConfigurationError as err:
-        LOGGER.error(str(err))
-        raise SystemExit(1)
-
-    succeeded, skipped, failed = [], [], []
-    for base_config in base_configs:
-        for layer in layers:
-            if args.resolve_branches:
-                layer.resolve_branch_to_commit_hash()
-            base_config.ensure_layer(layer, args.state)
-
-        if not base_config.changed:
-            skipped.append(base_config)
-            continue
-
-        try:
-            save_cfs_configuration(args, base_config)
-            succeeded.append(base_config)
-        except CFSConfigurationError as err:
-            LOGGER.error(str(err))
-            failed.append(base_config)
-
-    if skipped:
-        LOGGER.info(f'Skipped saving {len(skipped)} unchanged CFS configurations.')
-
-    if succeeded:
-        LOGGER.info(f'Successfully saved {len(succeeded)} changed CFS configurations.')
-
-    if failed:
-        LOGGER.error(f'Failed to save {len(failed)} CFS configurations.')
-        raise SystemExit(1)
+    functions_by_action = {
+        CANONICAL_UPDATE_CONFIGS_ACTION: do_update_configs,
+        CANONICAL_UPDATE_COMPONENTS_ACTION: do_update_components
+    }
+    do_action = functions_by_action.get(args.canonical_action)
+    do_action(args)

--- a/cfs_config_util/errors.py
+++ b/cfs_config_util/errors.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,5 +22,10 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 """
-Tests for the cfs_config_util.main module.
+Exception classes for errors which can occur in cfs-config-util
 """
+
+
+class CFSConfigUtilError(Exception):
+    """A generic error class for errors occurring in cfs-config-util"""
+    pass

--- a/cfs_config_util/hsm.py
+++ b/cfs_config_util/hsm.py
@@ -1,0 +1,63 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Utility functions for interacting with the Hardware State Manager (HSM) API
+"""
+from copy import deepcopy
+
+from cfs_config_util.errors import CFSConfigUtilError
+from csm_api_client.service.gateway import APIError
+
+
+def get_node_ids(hsm_client, component_ids=None, hsm_query=None):
+    """Get the node component IDs to which a CFS configuration should be applied.
+
+    Args:
+        component_ids (list, Optional): the list of explicit ids (xnames) given, if any
+        hsm_query (dict, Optional): HSM query parameters to find components
+        hsm_client (csm_api_client.service.hsm.HSMClient): the HSM API client
+
+    Returns:
+        list: the list of component ids (xnames)
+
+    Raises:
+        CFSConfigUtilError: if there is an error querying the HSM API
+    """
+    if component_ids is None:
+        component_ids = []
+    else:
+        # Make a copy to avoid modifying the passed in argument
+        component_ids = list(component_ids)
+
+    if hsm_query:
+        query_params = deepcopy(hsm_query)
+        query_params['type'] = 'Node'
+        try:
+            component_ids.extend(hsm_client.get_component_xnames(query_params))
+        except APIError as err:
+            raise CFSConfigUtilError(
+                f'Unable to query HSM for components matching parameters {query_params}: {err}'
+            ) from err
+
+    return component_ids

--- a/cfs_config_util/parser.py
+++ b/cfs_config_util/parser.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -26,6 +26,7 @@ Parser definition for cfs-config-util entry point.
 """
 
 import argparse
+from collections import defaultdict
 
 from csm_api_client.service.cfs import LayerState
 
@@ -43,6 +44,66 @@ SAVE_OPTION = '--save'
 SAVE_TO_FILE_OPTION = '--save-to-file'
 SAVE_TO_CFS_OPTION = '--save-to-cfs'
 SAVE_SUFFIX_OPTION = '--save-suffix'
+
+ASSIGN_TO_XNAMES_OPTION = '--assign-to-xnames'
+ASSIGN_TO_QUERY_OPTION = '--assign-to-query'
+
+CLEAR_STATE_OPTION = '--clear-state'
+CLEAR_ERROR_OPTION = '--clear-error'
+ENABLE_OPTION = '--enable'
+DISABLE_OPTION = '--disable'
+
+DESIRED_CONFIG_OPTION = '--desired-config'
+
+CANONICAL_UPDATE_CONFIGS_ACTION = 'update-configs'
+CANONICAL_UPDATE_COMPONENTS_ACTION = 'update-components'
+
+
+def convert_comma_separated_list(comma_separated_str):
+    """Convert a comma-separated list into a list.
+
+    Args:
+        comma_separated_str (str): the comma-separated list string to convert
+
+    Returns:
+        list: the converted list
+    """
+    return comma_separated_str.split(',')
+
+
+def convert_query_to_dict(query_str):
+    """Convert a comma-separated list of query parameters to a dictionary.
+
+    This splits a list of comma-separated items of the form "param=value" and
+    adds them to a dictionary mapping from param to the list of values for that
+    param. Multiple instances of a single param are added to a list of values.
+
+    For example "role=management,subrole=master,subrole=storage" becomes:
+
+    {
+        "role": ["management"]
+        "subrole": ["master", "storage"]
+    }
+
+    Args:
+        query_str (str): the comma-separated parameters
+
+    Returns:
+        dict: a dictionary mapping from parameter names to their string value
+            or values.
+    """
+    params = defaultdict(list)
+    for query in query_str.split(','):
+        try:
+            param, value = query.split('=', maxsplit=1)
+        except ValueError:
+            raise argparse.ArgumentTypeError(
+                f'Invalid query string "{query_str}". Query string must consist '
+                f'of one or more comma-separated key=value pairs.'
+            )
+        params[param].append(value)
+
+    return dict(params)
 
 
 def add_git_options(group):
@@ -154,7 +215,7 @@ def add_base_options(parser):
         help='The path to a file containing a CFS configuration payload.'
     )
     base_mutex_group.add_argument(
-        BASE_QUERY_OPTION,
+        BASE_QUERY_OPTION, type=convert_query_to_dict,
         help=f'A comma-separated list of key-value pairs to use to query '
              f'for HSM components, which will then be queried in CFS to '
              f'find a base configuration. Not compatible with {SAVE_TO_CFS_OPTION} '
@@ -202,10 +263,90 @@ def add_save_options(parser):
              f'discovered will be saved to a new CFS configuration with this '
              f'suffix.'
     )
+    save_group.add_argument(
+        '--create-backups', action='store_true',
+        help='If specified, save a backup of any configuration which is '
+             'overwritten.'
+    )
+
+
+def add_assign_options(parser):
+    """Add options which control how to assign the modified CFS configuration.
+
+    Args:
+        parser (argparse.ArgumentParser): the parser to which args are added
+    """
+    assign_group = parser.add_argument_group(
+        title='Assign Options',
+        description='Options that control how the modified CFS configuration '
+                    'is assigned to CFS components.'
+    )
+
+    assign_disclaimer = ('This option can only be used when a single CFS '
+                         'configuration is being created or modified.')
+
+    assign_group.add_argument(
+        ASSIGN_TO_XNAMES_OPTION, metavar='XNAME', type=convert_comma_separated_list,
+        help=f'A comma-separated list of xnames of CFS components to which the '
+             f'configuration should be assigned. {assign_disclaimer}'
+    )
+    assign_group.add_argument(
+        ASSIGN_TO_QUERY_OPTION, metavar='HSM_QUERY', type=convert_query_to_dict,
+        help=f'A comma-separated list of key-value pairs to use to query '
+             f'for HSM components. Matching CFS components will then have '
+             f'the configuration assigned. {assign_disclaimer}'
+    )
+
+
+def add_apply_options(parser):
+    """Add options which control how to apply a CFS configuration to components.
+
+    Args:
+        parser (argparse.ArgumentParser): the parser to which args are added
+
+    Returns:
+        argparse._ArgumentGroup: the argument group added to parser
+    """
+    apply_group = parser.add_argument_group(
+        title='Apply Options',
+        description='Options that control how the modified CFS configuration '
+                    'is applied to CFS components.'
+    )
+
+    apply_group.add_argument(
+        CLEAR_STATE_OPTION, action='store_true',
+        help='If specified, clear the state of the CFS components when the '
+             'configuration is assigned. This will force CFS to re-apply all '
+             'layers of the CFS configuration.'
+    )
+    apply_group.add_argument(
+        CLEAR_ERROR_OPTION, action='store_true',
+        help='If specified, clear the error count of the CFS components when '
+             'the configuration is assigned. This will allow CFS to attempt to '
+             're-apply a CFS configuration if the error count has been exceeded.'
+    )
+
+    enable_group = apply_group.add_mutually_exclusive_group()
+    enable_group.add_argument(
+        ENABLE_OPTION, action='store_true', dest='enabled', default=None,
+        help='If specified, ensure all CFS components affected are enabled.'
+    )
+    enable_group.add_argument(
+        DISABLE_OPTION, action='store_false', dest='enabled', default=None,
+        help='If specified, ensure all CFS components affected are disabled.'
+    )
+
+    apply_group.add_argument(
+        '--no-wait', action='store_false', dest='wait',
+        help='If specified, do not wait for the affected CFS components to '
+             'finish their configuration.'
+    )
+
+    return apply_group
 
 
 def base_given(args):
-    """Helper function which checks if a base was specified.
+    """Check if a base was specified.
 
     Returns:
         bool: True if any of --base-config, --base-file, or --base-query was
@@ -214,8 +355,40 @@ def base_given(args):
     return any([args.base_config, args.base_file, args.base_query])
 
 
-def check_args(args):
-    """Check that the specified args are compatible.
+def saves_to_cfs(args):
+    """Check if the resulting configuration will be saved to CFS.
+
+    Returns:
+        bool: True if the CFS configuration will be saved to CFS, False otherwise
+    """
+    # If explicitly saved to CFS or the base is in CFS and not being saved to a
+    # file, then the modified CFS configuration will be saved to CFS.
+    return bool(args.save_to_cfs or
+                ((args.base_config or args.base_query) and not args.save_to_file))
+
+
+def assign_requested(args):
+    """Check if assignment of a configuration to components was requested.
+
+    Returns:
+        bool: True if the admin requested that the CFS configuration be assigned
+            to CFS components.
+    """
+    return any([args.assign_to_xnames, args.assign_to_query])
+
+
+def apply_options_provided(args):
+    """Check if any options affecting how configurations are applied were specified.
+
+    Returns:
+        bool: True if the admin specified options affecting the application of
+            the configuration, False otherwise.
+    """
+    return any([args.clear_state, args.clear_error, args.enabled is not None])
+
+
+def check_update_configs_args(args):
+    """Check that the specified args to the update-configs action are compatible.
 
     Args:
         args (argparse.Namespace): the parsed command-line args
@@ -240,6 +413,57 @@ def check_args(args):
             f'or {GIT_COMMIT_OPTION} must be specified.'
         )
 
+    if assign_requested(args) and not saves_to_cfs(args):
+        raise ValueError(
+            f'The {ASSIGN_TO_XNAMES_OPTION} or {ASSIGN_TO_QUERY_OPTION} options '
+            f'require the resulting CFS configuration to be saved to CFS.'
+        )
+
+    if assign_requested(args) and args.base_query is not None:
+        raise ValueError(
+            f'{BASE_QUERY_OPTION} is not compatible with {ASSIGN_TO_QUERY_OPTION} '
+            f'or {ASSIGN_TO_XNAMES_OPTION}.'
+        )
+
+    if apply_options_provided(args) and not saves_to_cfs(args):
+        raise ValueError(
+            f'The options {CLEAR_STATE_OPTION}, {CLEAR_ERROR_OPTION}, '
+            f'{ENABLE_OPTION}, or {DISABLE_OPTION} require the resulting '
+            f'CFS configuration be saved to CFS.'
+        )
+
+
+def check_update_components_args(args):
+    """Check that the specified args to the update-components action are compatible.
+
+    Args:
+        args (argparse.Namespace): the parsed command-line args
+
+    Raises:
+        ValueError: if any incompatible args are specified.
+    """
+    if not any([args.desired_config, args.clear_state, args.clear_error, args.enabled is not None]):
+        raise ValueError(
+            f'At least one of the options {DESIRED_CONFIG_OPTION}, '
+            f'{CLEAR_STATE_OPTION}, {CLEAR_ERROR_OPTION}, {ENABLE_OPTION}, '
+            f'or {DISABLE_OPTION} must be specified.'
+        )
+
+
+def check_args(args):
+    """Check that the specified args are compatible.
+
+    Args:
+        args (argparse.Namespace): the parsed command-line args
+
+    Raises:
+        ValueError: if any incompatible args are specified.
+    """
+    if args.canonical_action == CANONICAL_UPDATE_CONFIGS_ACTION:
+        check_update_configs_args(args)
+    elif args.canonical_action == CANONICAL_UPDATE_COMPONENTS_ACTION:
+        check_update_components_args(args)
+
 
 def create_passthrough_parser():
     """Create a parser for options that can be passed through product install scripts.
@@ -259,6 +483,7 @@ def create_passthrough_parser():
     """
     parser = argparse.ArgumentParser(add_help=False, usage=argparse.SUPPRESS, allow_abbrev=False)
 
+    # Add subset of the options added by add_layer_content_options
     git_group = parser.add_argument_group(
         title='Git Options',
         description='Options that control the git ref used in the layer.'
@@ -266,8 +491,80 @@ def create_passthrough_parser():
     add_git_options(git_group)
     add_base_options(parser)
     add_save_options(parser)
+    add_assign_options(parser)
 
     return parser
+
+
+def add_update_configs_subparser(subparsers):
+    """Add the update-configs subparser to the parent parser.
+
+    The update-configs action is used to modify create a new CFS configuration
+    or modify an existing one. This action used to be the default behavior when
+    no action was given.
+
+    Args:
+        subparsers (argparse._SubParsersAction): the object to which subparsers
+            can be added with add_subparser
+
+    Returns: None
+    """
+    subparser = subparsers.add_parser(
+        CANONICAL_UPDATE_CONFIGS_ACTION, help='Update CFS configurations.',
+        aliases=['update-config', 'update-configurations', 'update-configuration'],
+        description='Update one or more CFS configurations and optionally '
+                    'assign them to components in CFS.'
+    )
+    subparser.set_defaults(canonical_action=CANONICAL_UPDATE_CONFIGS_ACTION)
+
+    add_layer_content_options(subparser)
+    add_base_options(subparser)
+    add_save_options(subparser)
+    add_assign_options(subparser)
+    add_apply_options(subparser)
+
+
+def add_update_components_subparser(subparsers):
+    """Add the update-components subparser to the parent parser.
+
+    The update-components action is used to update the attributes of CFS components,
+    including their desiredConfig, enabled, errorCount, and state attributes. It
+    will also wait for the components to reach a configured state if a change which
+    would trigger CFS Batcher is made.
+
+    Args:
+        subparsers (argparse._SubParsersAction): the object to which subparsers
+            can be added with add_subparser
+
+    Returns: None
+    """
+    subparser = subparsers.add_parser(
+        CANONICAL_UPDATE_COMPONENTS_ACTION, help='Update CFS components.',
+        aliases=['update-component'],
+        description='Update CFS components and optionally wait for them to become '
+                    'configured by CFS Batcher.'
+    )
+    subparser.set_defaults(canonical_action=CANONICAL_UPDATE_COMPONENTS_ACTION)
+
+    subparser.add_argument(
+        '--xnames', metavar='XNAME', type=convert_comma_separated_list,
+        help=f'A comma-separated list of xnames of CFS components which should '
+             f'be updated.'
+    )
+    subparser.add_argument(
+        '--query', metavar='HSM_QUERY', type=convert_query_to_dict,
+        help=f'A comma-separated list of key-value pairs to use to query '
+             f'for HSM components. Matching CFS components will then have '
+             f'the specified configuration assigned.'
+    )
+
+    apply_group = add_apply_options(subparser)
+    apply_group.add_argument(
+        DESIRED_CONFIG_OPTION,
+        help=f'The CFS configuration which should be set as the desiredConfig '
+             f'for the given components. If not specified, the desiredConfig is '
+             f'not set on the components.'
+    )
 
 
 def create_parser():
@@ -278,8 +575,8 @@ def create_parser():
     """
     parser = argparse.ArgumentParser(allow_abbrev=False)
 
-    add_layer_content_options(parser)
-    add_base_options(parser)
-    add_save_options(parser)
+    subparsers = parser.add_subparsers(metavar='action', dest='action')
+    add_update_configs_subparser(subparsers)
+    add_update_components_subparser(subparsers)
 
     return parser

--- a/cfs_config_util/update_components.py
+++ b/cfs_config_util/update_components.py
@@ -1,0 +1,109 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Implementation of the update-components action of cfs-config-utility
+"""
+import logging
+
+from cfs_config_util.environment import (
+    API_CERT_VERIFY,
+    API_GW_HOST,
+)
+from cfs_config_util.errors import CFSConfigUtilError
+from cfs_config_util.hsm import get_node_ids
+from cfs_config_util.wait import wait_for_component_configuration
+
+from csm_api_client.service.cfs import (
+    CFSClient
+)
+from csm_api_client.service.gateway import APIError
+from csm_api_client.service.hsm import HSMClient
+from csm_api_client.session import AdminSession
+
+LOGGER = logging.getLogger(__name__)
+
+
+def update_cfs_components(cfs_client, component_ids, desired_config=None, clear_state=None,
+                          clear_error=None, enabled=None):
+    """Assign the CFSConfiguration to the given CFS components.
+
+    Args:
+        cfs_client (csm_api_client.service.cfs.CFSClient): the CFS API client
+        component_ids (Iterable): the list of component ids (xnames) to update
+        desired_config (str, Optional): the name of the desired config to set
+            on the components, if any
+        clear_state (bool, Optional): if True, clear state of the component
+        clear_error (bool, Optional): if True, clear errorCount of the component
+        enabled (bool, Optional): if specified, set the enabled of the component
+
+    Returns:
+        None
+
+    Raises:
+        CFSConfigUtilError: if unable to assign the CFS configuration to any
+            of the requested components.
+    """
+    failed_components = []
+    for component_id in component_ids:
+        try:
+            cfs_client.update_component(component_id, desired_config=desired_config,
+                                        clear_state=clear_state, clear_error=clear_error,
+                                        enabled=enabled)
+        except APIError as err:
+            LOGGER.error(f'Failed to update CFS component {component_id}: {err}')
+            failed_components.append(component_id)
+
+    if failed_components:
+        raise CFSConfigUtilError(f'Failed to update {len(failed_components)} '
+                                 f'CFS components: {", ".join(failed_components)}')
+
+    LOGGER.info(f'Updated {len(component_ids)} CFS components.')
+
+
+def do_update_components(args):
+    """Update CFS components.
+
+    Args:
+        args (argparse.Namespace): the parsed command-line arguments
+    """
+    session = AdminSession(API_GW_HOST, API_CERT_VERIFY)
+    hsm_client = HSMClient(session)
+    cfs_client = CFSClient(session)
+
+    component_ids = get_node_ids(hsm_client, component_ids=args.xnames,
+                                 hsm_query=args.query)
+    LOGGER.info(f'Found {len(component_ids)} CFS components to update.')
+
+    try:
+        update_cfs_components(
+            cfs_client, component_ids, desired_config=args.desired_config,
+            clear_state=args.clear_state, clear_error=args.clear_error,
+            enabled=args.enabled
+        )
+    except CFSConfigUtilError as err:
+        LOGGER.error(str(err))
+        raise SystemExit(1)
+
+    if args.wait:
+        wait_for_component_configuration(cfs_client, component_ids)

--- a/cfs_config_util/update_configs.py
+++ b/cfs_config_util/update_configs.py
@@ -1,0 +1,363 @@
+#
+# MIT License
+#
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Implementation of the update-configs action of cfs-config-utility
+"""
+from copy import deepcopy
+from datetime import datetime
+import json
+import logging
+
+from csm_api_client.service.cfs import (
+    CFSClient,
+    CFSConfiguration,
+    CFSConfigurationError,
+    CFSConfigurationLayer
+)
+from csm_api_client.service.gateway import APIError
+from csm_api_client.service.hsm import HSMClient
+from csm_api_client.session import AdminSession
+
+from cfs_config_util.environment import (
+    API_CERT_VERIFY,
+    API_GW_HOST,
+)
+from cfs_config_util.errors import CFSConfigUtilError
+from cfs_config_util.hsm import get_node_ids
+from cfs_config_util.parser import (
+    base_given,
+    apply_options_provided,
+    assign_requested
+)
+from cfs_config_util.update_components import update_cfs_components
+from cfs_config_util.wait import wait_for_component_configuration
+
+LOGGER = logging.getLogger(__name__)
+
+
+def get_cfs_configurations(args, cfs_client, hsm_client):
+    """Get the CFSConfigurations from CFS or from a file.
+
+    Args:
+        args (argparse.Namespace): the parsed command-line args
+        cfs_client (csm_api_client.service.cfs.CFSClient): the CFS API client
+        hsm_client (cfs_config_util.apiclient.HSMClient): the HSM API client
+
+    Returns:
+        list of csm_api_client.service.cfs.CFSConfiguration: the CFS configurations
+            from CFS or loaded from a file. If a name of a CFS config or a file
+            name is given, the list will have only one element.
+
+    Raises:
+        CFSConfigurationError: if unable get the CFS configuration from the CFS
+            API or unable to load it from a file
+    """
+    if args.base_config is not None:
+        # Get the CFSConfiguration from the CFS API
+        try:
+            return [cfs_client.get_configuration(args.base_config)]
+        except APIError as err:
+            raise CFSConfigurationError(f'Could not retrieve configuration '
+                                        f'"{args.base_config}" from CFS: {err}') from err
+
+    elif args.base_query is not None:
+        # Only HSM components of type Node have corresponding CFS components
+        hsm_query_params = deepcopy(args.base_query)
+        hsm_query_params['type'] = 'Node'
+        try:
+            configs = cfs_client.get_configurations_for_components(hsm_client, **hsm_query_params)
+            if not configs:
+                raise CFSConfigurationError(
+                    f'No configurations were found for components matching the '
+                    f'query "{hsm_query_params}".'
+                )
+            return configs
+        except APIError as err:
+            raise CFSConfigurationError(
+                f'Could not retrieve CFS configurations for HSM components '
+                f'matching the query "{hsm_query_params}": {err}'
+            )
+
+    else:
+        # args.base_file must have been specified, so load from a file
+        try:
+            with open(args.base_file, 'r') as f:
+                file_data = json.load(f)
+        except OSError as err:
+            raise CFSConfigurationError(f'Failed to open file {args.base_file}: {err}')
+        except json.decoder.JSONDecodeError as err:
+            raise CFSConfigurationError(f'Failed to parse JSON in file {args.base_file}: {err}')
+
+        return [CFSConfiguration(cfs_client, file_data)]
+
+
+def construct_layers(args):
+    """Construct CFSConfigurationLayer(s) which should be added or removed from a CFSConfiguration.
+
+    Args:
+        args (argparse.Namespace): the parsed command-line args
+
+    Returns:
+        List[CFSConfigurationLayer]: the layers that should be added or removed
+
+    Raises:
+        CFSConfigurationError: if unable to construct the requested layer
+    """
+    # These kwargs are common between both layers defined by clone URL and layers
+    # defined by product.
+    layers = []
+    playbooks = args.playbooks
+
+    # If the --playbook option is not supplied, then only create one layer with
+    # the default playbook. Passing `None` as the playbook argument to the
+    # layer creation methods achieves this.
+    if playbooks is None:
+        playbooks = [None]
+
+    for playbook in playbooks:
+        common_args = {
+            'name': args.layer_name,
+            'playbook': playbook,
+            'commit': args.git_commit,
+            'branch': args.git_branch
+        }
+        if args.product:
+            if ':' in args.product:
+                product_name, product_version = args.product.split(':', maxsplit=1)
+            else:
+                product_name = args.product
+                product_version = None
+            layers.append(
+                CFSConfigurationLayer.from_product_catalog(
+                    product_name, API_GW_HOST, product_version=product_version, **common_args)
+            )
+        else:
+            layers.append(
+                CFSConfigurationLayer.from_clone_url(args.clone_url, **common_args)
+            )
+    return layers
+
+
+def save_cfs_configuration(args, cfs_config):
+    """Save the CFSConfiguration to a file or to CFS per the command-line args.
+
+    Args:
+        args (argparse.Namespace): the parsed command-line args
+        cfs_config (csm_api_client.service.cfs.CFSConfiguration): the modified
+            CFS configuration to save
+
+    Returns:
+        CFSConfiguration or None: if a new CFS configuration was saved to CFS,
+            return the new CFSConfiguration object.
+
+    Raises:
+        CFSConfigurationError: if unable to save the CFS configuration to CFS
+            or to a file.
+    """
+    backup_suffix = None
+    if args.create_backups:
+        backup_suffix = f'-backup-{datetime.now().strftime("%Y%m%dT%H%M%S")}'
+
+    if args.save:
+        if args.base_config or args.base_query:
+            # Overwrite the CFS configuration in CFS
+            return cfs_config.save_to_cfs(backup_suffix=backup_suffix)
+        else:
+            # args.base_file; overwrite the file in place
+            cfs_config.save_to_file(args.base_file, backup_suffix=backup_suffix)
+
+    elif args.save_suffix:
+        if args.base_config or args.base_query:
+            return cfs_config.save_to_cfs(f'{cfs_config.name}{args.save_suffix}',
+                                          backup_suffix=backup_suffix)
+        else:
+            cfs_config.save_to_file(f'{args.base_file}{args.save_suffix}',
+                                    backup_suffix=backup_suffix)
+
+    elif args.save_to_cfs:
+        return cfs_config.save_to_cfs(args.save_to_cfs, overwrite=base_given(args),
+                                      backup_suffix=backup_suffix)
+
+    elif args.save_to_file:
+        cfs_config.save_to_file(args.save_to_file, overwrite=base_given(args),
+                                backup_suffix=backup_suffix)
+
+
+def get_affected_components(cfs_client, cfs_configs):
+    """Get CFS components which have one of the configs as their desiredConfig.
+
+    Args:
+        cfs_client (csm_api_client.service.cfs.CFSClient): the CFS API client
+        cfs_configs (csm_api_client.service.cfs.CFSConfiguration): the CFS
+            configurations to check
+
+    Returns:
+        set: the IDs of the CFS components which use any of the given
+            `cfs_configurations`
+
+    Raises:
+         CFSConfigUtilError: if there is a failure to get affected components
+    """
+    affected_components = set()
+    for cfs_config in cfs_configs:
+        try:
+            affected_components.update(cfs_client.get_component_ids_using_config(cfs_config.name))
+        except APIError as err:
+            raise CFSConfigUtilError(f'Failed to get affected components: {err}') from err
+
+    return affected_components
+
+
+def update_configurations(args, cfs_client, hsm_client):
+    """Update the CFS configurations as requested by command-line args
+
+    Args:
+        args (argparse.Namespace): the parsed command-line arguments
+        cfs_client (csm_api_client.service.cfs.CFSClient): the CFS API client
+        hsm_client (csm_api_client.service.hsm.HSMClient): the HSM API client
+
+    Returns:
+        A tuple consisting of the CFSConfiguration objects which have been
+        updated and those which did not need to be updated.
+    """
+    try:
+        if base_given(args):
+            base_configs = get_cfs_configurations(args, cfs_client, hsm_client)
+        else:
+            LOGGER.info('No base configuration given. Starting from empty configuration. '
+                        'Existing configurations will not be overwritten.')
+            base_configs = [CFSConfiguration.empty(cfs_client)]
+
+        layers = construct_layers(args)
+
+    except CFSConfigurationError as err:
+        LOGGER.error(str(err))
+        raise SystemExit(1)
+
+    # List of CFS configs which were updated in CFS, updated in a file, not modified, or failed
+    updated_cfs_configs, updated_file_configs, unmodified_configs, failed = [], [], [], []
+    for base_config in base_configs:
+        for layer in layers:
+            if args.resolve_branches:
+                layer.resolve_branch_to_commit_hash()
+            base_config.ensure_layer(layer, args.state)
+
+        if not base_config.changed:
+            unmodified_configs.append(base_config)
+            continue
+
+        try:
+            updated_config = save_cfs_configuration(args, base_config)
+            if updated_config is None:
+                updated_file_configs.append(base_config)
+            else:
+                updated_cfs_configs.append(updated_config)
+        except CFSConfigurationError as err:
+            LOGGER.error(str(err))
+            failed.append(base_config)
+
+    if unmodified_configs:
+        LOGGER.info(f'Skipped saving {len(unmodified_configs)} unchanged CFS configuration(s).')
+    if updated_cfs_configs:
+        LOGGER.info(f'Successfully saved {len(updated_cfs_configs)} changed CFS '
+                    f'configuration(s) to CFS.')
+    if updated_file_configs:
+        LOGGER.info(f'Successfully saved {len(updated_cfs_configs)} changed CFS '
+                    f'configuration(s) to file(s).')
+    if failed:
+        LOGGER.error(f'Failed to save {len(failed)} CFS configuration(s).')
+        raise SystemExit(1)
+
+    return updated_cfs_configs, unmodified_configs
+
+
+def assign_configuration(args, cfs_client, hsm_client, cfs_config_name):
+    """Assign a configuration to the components according to CLI args.
+
+    Args:
+        args (argparse.Namespace): the parsed command-line arguments
+        cfs_client (csm_api_client.service.cfs.CFSClient): the CFS API client
+        hsm_client (csm_api_client.service.hsm.HSMClient): the HSM API client
+        cfs_config_name (str): CFS configuration name to assign to components
+
+    Returns:
+        list of str: component IDs to which configuration was assigned
+    """
+    try:
+        assign_components = get_node_ids(hsm_client, component_ids=args.assign_to_xnames,
+                                         hsm_query=args.assign_to_query)
+    except CFSConfigUtilError as err:
+        LOGGER.error(f'Failed to get components to which configuration '
+                     f'should be assigned: {err}')
+        raise SystemExit(1)
+
+    try:
+        update_cfs_components(
+            cfs_client, assign_components, desired_config=cfs_config_name,
+            clear_state=args.clear_state, clear_error=args.clear_error, enabled=args.enabled
+        )
+    except CFSConfigUtilError as err:
+        LOGGER.error(f'Failed to update CFS components: {err}')
+        raise SystemExit(1)
+
+    return assign_components
+
+
+def do_update_configs(args):
+    """Update or create a CFS configuration.
+
+    Args:
+        args (argparse.Namespace): the parsed command-line arguments
+    """
+    session = AdminSession(API_GW_HOST, API_CERT_VERIFY)
+    hsm_client = HSMClient(session)
+    cfs_client = CFSClient(session)
+
+    modified_configs, unmodified_configs = update_configurations(args, cfs_client, hsm_client)
+
+    # These components are using a CFS configuration updated above
+    affected_components = get_affected_components(cfs_client, modified_configs)
+    # Update these components' other fields as requested by "Apply Options"
+    if apply_options_provided(args):
+        update_cfs_components(cfs_client, affected_components, clear_state=args.clear_state,
+                              clear_error=args.clear_error, enabled=args.enabled)
+
+    # Assign the configuration to any components as requested
+    assigned_components = []
+    if assign_requested(args):
+        all_configs = modified_configs + unmodified_configs
+
+        # Neither of these cases should happen given how arguments are checked,
+        # specifically that --base-query and assign are not allowed together
+        if len(all_configs) != 1:
+            LOGGER.error(f'Expected a single configuration to apply to CFS '
+                         f'components but found {len(all_configs)}')
+            raise SystemExit(1)
+
+        assigned_components = assign_configuration(args, cfs_client, hsm_client, all_configs[0].name)
+
+    affected_components.update(assigned_components)
+
+    if args.wait and affected_components:
+        wait_for_component_configuration(cfs_client, affected_components)

--- a/cfs_config_util/wait.py
+++ b/cfs_config_util/wait.py
@@ -1,0 +1,140 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Functions for waiting on CFS components to become configured.
+"""
+from collections import defaultdict
+import logging
+import time
+
+from csm_api_client.service.gateway import APIError
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def get_components_by_status(cfs_client, component_ids):
+    """Get a dict mapping component state to a list of components in that state.
+
+    Args:
+        cfs_client (csm_api_client.service.cfs.CFSClient): the CFS API client
+        component_ids (Iterable): the component IDs to query
+
+    Returns:
+        tuple: a tuple (components_by_status, disabled_components, error_components)
+            components_by_status: a dictionary mapping from CFS component state
+                to a set of components in that state
+            disabled_components: a set of components which are disabled
+            error_components: a set of components which could not be queried in
+                CFS
+    """
+    disabled_components = set()
+    error_components = set()
+    components_by_status = defaultdict(set)
+    for component_id in component_ids:
+        try:
+            component_data = cfs_client.get('components', component_id).json()
+        except (APIError, ValueError) as err:
+            LOGGER.error(f'Failed to get CFS component "{component_id}": {err}')
+            error_components.add(component_id)
+        else:
+            if component_data['enabled']:
+                components_by_status[component_data['configurationStatus']].add(component_id)
+            else:
+                disabled_components.add(component_id)
+
+    return components_by_status, disabled_components, error_components
+
+
+def log_component_status_summary(components_by_status):
+
+    summary = ", ".join(f'{status}: {len(ids)}'
+                        for status, ids in components_by_status.items()
+                        if ids)
+    if summary:
+        LOGGER.info(f'Summary of number of components in each status: {summary}')
+
+
+def wait_for_component_configuration(cfs_client, wait_component_ids, check_interval=30):
+    """Wait for CFS components to finish their configuration.
+
+    This means waiting until all components have exited the "pending" state
+    and reached either "configured" or "failed" states.
+
+    Args:
+        cfs_client (csm_api_client.service.cfs.CFSClient): the CFS API client
+        wait_component_ids (Iterable): the component IDs to wait on
+        check_interval (int): the number of seconds to wait between checks on
+            component state
+
+    Returns:
+        None
+    """
+    LOGGER.info(f'Waiting for {len(wait_component_ids)} component(s) to finish '
+                f'configuration')
+
+    components_by_status, disabled_components, error_components = \
+        get_components_by_status(cfs_client, wait_component_ids)
+
+    if disabled_components:
+        LOGGER.info(f'Ignoring {len(disabled_components)} disabled component(s): '
+                    f'{", ".join(disabled_components)}')
+    if error_components:
+        LOGGER.warning(f'Ignoring {len(error_components)} component(s) which could not '
+                       f'be queried: {", ".join(error_components)}')
+
+    log_component_status_summary(components_by_status)
+
+    pending_components = components_by_status['pending']
+    LOGGER.info(f'Waiting for {len(pending_components)} pending component(s)')
+
+    while pending_components:
+        LOGGER.info(f'Sleeping for {check_interval} seconds before checking '
+                    f'status of {len(pending_components)} pending component(s).')
+        time.sleep(check_interval)
+
+        new_components_by_status, new_disabled_components, new_error_components = \
+            get_components_by_status(cfs_client, pending_components)
+
+        for status, component_ids in new_components_by_status.items():
+            if status != 'pending':
+                LOGGER.info(f'{len(component_ids)} pending components transitioned '
+                            f'to status {status}: {", ".join(component_ids)}')
+                components_by_status[status].update(component_ids)
+                pending_components -= component_ids
+
+        if new_error_components:
+            error_components.extend(new_error_components)
+            pending_components -= new_error_components
+        if new_disabled_components:
+            LOGGER.info(f'{len(new_disabled_components)} component(s) have been '
+                        f'disabled: {", ".join(disabled_components)}')
+            pending_components -= new_disabled_components
+
+    if error_components:
+        LOGGER.warning(f'Failed to get status of {len(error_components)} component(s).')
+
+    LOGGER.info(f'Finished waiting for {len(wait_component_ids)} '
+                f'component(s) to finish configuration.')
+    log_component_status_summary(components_by_status)

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -6,7 +6,7 @@ certifi==2023.7.22
 charset-normalizer==2.1.1
 coverage==6.0.2
 cray-product-catalog==1.8.12
-csm-api-client==1.1.5
+csm-api-client==1.2.0
 google-auth==2.11.0
 idna==3.4
 inflect==6.0.0

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -5,7 +5,7 @@ cachetools==5.2.0
 certifi==2023.7.22
 charset-normalizer==2.1.1
 cray-product-catalog==1.8.12
-csm-api-client==1.1.5
+csm-api-client==1.2.0
 google-auth==2.11.0
 idna==3.4
 inflect==6.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 cray-product-catalog >= 1.6.0
-csm-api-client >= 1.0, < 2.0
+csm-api-client >= 1.2, < 2.0

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -33,15 +33,49 @@ from unittest.mock import patch
 
 from csm_api_client.service.cfs import LayerState
 
-from cfs_config_util.parser import check_args, create_parser, create_passthrough_parser
+from cfs_config_util.parser import check_args, convert_query_to_dict, create_parser, create_passthrough_parser
 
 
-class TestParseAndCheckArgs(unittest.TestCase):
-    """Tests for parse_args and check_args"""
+class TestConvertQueryToDict(unittest.TestCase):
+
+    def test_single_key_value(self):
+        """Test convert_query_to_dict on a single 'key=value' pair"""
+        converted = convert_query_to_dict('role=management')
+        self.assertEqual({'role': ['management']}, converted)
+
+    def test_multiple_key_value(self):
+        """Test convert_query_to_dict on multiple 'key=value' pairs"""
+        converted = convert_query_to_dict('role=management,subrole=storage')
+        self.assertEqual({'role': ['management'], 'subrole': ['storage']}, converted)
+
+    def test_multiple_key_value_with_repeats(self):
+        """Test convert_query_to_dict on multiple 'key=value' pairs with a repeated key"""
+        converted = convert_query_to_dict('role=management,subrole=storage,subrole=master')
+        self.assertEqual({'role': ['management'], 'subrole': ['storage', 'master']}, converted)
+
+
+class TestParseArgsBase(unittest.TestCase):
+    """Base class for argument parsing tests"""
+    def assert_parse_error(self, args, err_regex=None):
+        f = io.StringIO()
+        with contextlib.redirect_stderr(f):
+            with self.assertRaises(SystemExit) as err_cm:
+                self.parser.parse_args(args)
+
+        self.assertEqual(2, err_cm.exception.code)
+
+        if err_regex:
+            self.assertRegex(f.getvalue(), err_regex)
+
+
+class TestUpdateConfigParseAndCheckArgs(TestParseArgsBase):
+    """Tests for parse_args and check_args with update-config action."""
 
     def setUp(self):
         """Create a parser to use in the tests."""
         self.parser = create_parser()
+
+        self.action_args = ['update-config']
 
         self.product_layer_args = ['--product', 'sat:2.2.16']
         self.clone_url_branch_args = [
@@ -64,25 +98,35 @@ class TestParseAndCheckArgs(unittest.TestCase):
         self.save_alternatives = [self.save_args, self.save_to_cfs_args,
                                   self.save_to_file_args, self.save_suffix_args]
 
+        self.assign_to_xnames_args = ['--assign-to-xnames', 'x3000c0s1b0n0,x3000c0s3b0n0']
+        self.assign_to_query_args = ['--assign-to-query', 'role=management,subrole=master']
+        # These two assign options are not mutually exclusive
+        self.assign_alternatives = [self.assign_to_xnames_args, self.assign_to_query_args,
+                                    self.assign_to_xnames_args + self.assign_to_query_args]
+
+        self.clear_state_args = ['--clear-state']
+        self.clear_error_args = ['--clear-error']
+        self.enable_args = ['--enable']
+        self.disable_args = ['--disable']
+        self.apply_alternatives = [
+            self.clear_state_args + self.clear_error_args + self.enable_args,
+            self.clear_state_args + self.clear_error_args + self.disable_args,
+            self.clear_state_args + self.enable_args,
+            self.clear_state_args + self.disable_args,
+            self.clear_error_args + self.enable_args,
+            self.clear_error_args + self.disable_args,
+            self.enable_args,
+            self.disable_args
+        ]
+
         self.missing_args_msg = 'one of the arguments .* is required'
-
-    def assert_parse_error(self, args, err_regex=None):
-        f = io.StringIO()
-        with contextlib.redirect_stderr(f):
-            with self.assertRaises(SystemExit) as err_cm:
-                self.parser.parse_args(args)
-
-        self.assertEqual(2, err_cm.exception.code)
-
-        if err_regex:
-            self.assertRegex(f.getvalue(), err_regex)
 
     def test_parse_and_check_combinations(self):
         """Test parsing args when given various combinations of args."""
         for layer_args, base_args, save_args in itertools.product(self.layer_alternatives,
-                                                                  self.base_alternatives + [],
+                                                                  self.base_alternatives + [[]],
                                                                   self.save_alternatives):
-            full_args = layer_args + base_args + save_args
+            full_args = self.action_args + layer_args + base_args + save_args
             with self.subTest(full_args=full_args):
                 # If using --base-query, then must use --save or --save-suffix.
                 # If not using any --base*, cannot use --save or --save-suffix.
@@ -99,7 +143,7 @@ class TestParseAndCheckArgs(unittest.TestCase):
 
     def test_parse_invalid_clone_url_layer(self):
         """Test parsing args when given a clone URL without a branch or commit hash."""
-        parsed_args = self.parser.parse_args(self.clone_url_branch_args[:2] +
+        parsed_args = self.parser.parse_args(self.action_args + self.clone_url_branch_args[:2] +
                                              self.base_config_args + self.save_args)
         with self.assertRaises(ValueError):
             check_args(parsed_args)
@@ -107,7 +151,7 @@ class TestParseAndCheckArgs(unittest.TestCase):
     def test_save_args_mutually_exclusive(self):
         """Test parsing raises error when given multiple mutually exclusive save options."""
         for mutex_args in itertools.combinations(self.save_alternatives, 2):
-            full_args = self.base_config_args + self.product_layer_args
+            full_args = self.action_args + self.base_config_args + self.product_layer_args
             full_args += itertools.chain.from_iterable(mutex_args)
             with self.subTest(full_args=full_args):
                 self.assert_parse_error(full_args, 'not allowed with argument')
@@ -115,19 +159,19 @@ class TestParseAndCheckArgs(unittest.TestCase):
     def test_base_options_mutually_exclusive(self):
         """Test parsing raises error when given multiple mutually exclusive base options."""
         for mutex_args in itertools.combinations(self.base_alternatives, 2):
-            full_args = self.product_layer_args + self.save_args
+            full_args = self.action_args + self.product_layer_args + self.save_args
             full_args += itertools.chain.from_iterable(mutex_args)
             with self.subTest(full_args=full_args):
                 self.assert_parse_error(full_args, 'not allowed with argument')
 
     def test_missing_layer_args(self):
         """Test parsing when missing an arg that defines the layer."""
-        self.assert_parse_error(self.base_config_args + self.save_args,
+        self.assert_parse_error(self.action_args + self.base_config_args + self.save_args,
                                 self.missing_args_msg)
 
     def test_missing_save_args(self):
         """Test parsing when missing an argument specifying how the config should be saved."""
-        self.assert_parse_error(self.product_layer_args + self.base_config_args,
+        self.assert_parse_error(self.action_args + self.product_layer_args + self.base_config_args,
                                 self.missing_args_msg)
 
     def test_valid_state_args(self):
@@ -135,15 +179,153 @@ class TestParseAndCheckArgs(unittest.TestCase):
         for arg_val, layer_state in [('present', LayerState.PRESENT), ('absent', LayerState.ABSENT)]:
             with self.subTest(state=arg_val):
                 parsed_args = self.parser.parse_args(
-                    self.product_layer_args + self.base_config_args + self.save_args +
+                    self.action_args + self.product_layer_args + self.base_config_args + self.save_args +
                     ['--state', arg_val]
                 )
                 self.assertEqual(layer_state, parsed_args.state)
 
     def test_invalid_state_arg(self):
         """Test parsing with an invalid state arg."""
-        full_args = self.product_layer_args + self.base_config_args + self.save_args + ['--state', 'gone']
+        full_args = self.action_args + self.product_layer_args + \
+            self.base_config_args + self.save_args + ['--state', 'gone']
         self.assert_parse_error(full_args, '--state: invalid')
+
+    def test_valid_assign_arg_combos(self):
+        """Test parsing with valid --assign-to-args and --assign-to-query arguments"""
+        valid_combos = [
+            # Start from a base CFS configuration and save in-place
+            self.base_config_args + self.save_args,
+            # Start from a base CFS configuration and save with a suffix
+            self.base_config_args + self.save_suffix_args,
+            # Start from a base CFS configuration and save to a new CFS configuration
+            self.base_config_args + self.save_to_cfs_args,
+            # Start from a base file and save to CFS
+            self.base_file_args + self.save_to_cfs_args,
+        ]
+
+        for layer_args in self.layer_alternatives:
+            for assign_args in self.assign_alternatives:
+                for arg_combo in valid_combos:
+                    full_args = self.action_args + layer_args + arg_combo + assign_args
+                    with self.subTest(full_args=full_args):
+                        parsed_args = self.parser.parse_args(full_args)
+                        check_args(parsed_args)
+
+    def test_invalid_assign_arg_not_saved_to_cfs(self):
+        """Test parsing with invalid --assign* specified when not saving to CFS"""
+        # All these invalid combinations save to a file, which cannot then be
+        # assigned to a CFS component
+        invalid_combos = [
+            # Start from a base CFS configuration and save to a file
+            self.base_config_args + self.save_to_file_args,
+            # Start from a base file and save in place
+            self.base_file_args + self.save_args,
+            # Start from a base file and save to a new file
+            self.base_file_args + self.save_to_file_args,
+            # Start from a base file and save to a file with a suffix
+            self.base_file_args + self.save_suffix_args,
+        ]
+        expected_err_regex = (
+            'The --assign-to-xnames or --assign-to-query options require the '
+            'resulting CFS configuration to be saved to CFS.'
+        )
+
+        for layer_args, assign_args, arg_combo in itertools.product(self.layer_alternatives,
+                                                                    self.assign_alternatives,
+                                                                    invalid_combos):
+            full_args = self.action_args + layer_args + arg_combo + assign_args
+            with self.subTest(full_args=full_args):
+                parsed_args = self.parser.parse_args(full_args)
+                with self.assertRaisesRegex(ValueError, expected_err_regex):
+                    check_args(parsed_args)
+
+    def test_invalid_assign_arg_with_base_query(self):
+        """Test parsing with invalid --assign* specified with --base-query"""
+        # Both these combinations use --base-query, which can match more than
+        # one CFS configuration, which means they can't both be assigned to components
+        invalid_combos = [
+            # Start from a base query and save in place
+            self.base_query_args + self.save_args,
+            # Start from a base query and save with a suffix
+            self.base_query_args + self.save_suffix_args
+        ]
+        expected_err_regex = (
+            '--base-query is not compatible with --assign-to-query or --assign-to-xnames'
+        )
+
+        for layer_args, assign_args, arg_combo in itertools.product(self.layer_alternatives,
+                                                                    self.assign_alternatives,
+                                                                    invalid_combos):
+            full_args = self.action_args + layer_args + arg_combo + assign_args
+            with self.subTest(full_args=full_args):
+                parsed_args = self.parser.parse_args(full_args)
+                with self.assertRaisesRegex(ValueError, expected_err_regex):
+                    check_args(parsed_args)
+
+    def test_valid_apply_args_no_assign(self):
+        """Test parsing with valid apply arguments without assignment"""
+        valid_combos = [
+            self.base_query_args + self.save_args,
+            self.base_query_args + self.save_suffix_args,
+            self.base_config_args + self.save_args,
+            self.base_config_args + self.save_suffix_args,
+            self.base_config_args + self.save_to_cfs_args,
+            self.base_file_args + self.save_to_cfs_args,
+        ]
+        for layer_args, arg_combo, apply_args in itertools.product(self.layer_alternatives,
+                                                                   valid_combos,
+                                                                   self.apply_alternatives):
+            full_args = self.action_args + layer_args + arg_combo + apply_args
+            with self.subTest(full_args=full_args):
+                parsed_args = self.parser.parse_args(full_args)
+                check_args(parsed_args)
+
+    def test_valid_apply_args_with_assign(self):
+        """Test parsing with valid apply arguments with assignment"""
+        valid_combos = [
+            self.base_config_args + self.save_args,
+            self.base_config_args + self.save_suffix_args,
+            self.base_config_args + self.save_to_cfs_args,
+            self.base_file_args + self.save_to_cfs_args,
+        ]
+        for layer_args, assign_args, arg_combo, apply_args in itertools.product(self.layer_alternatives,
+                                                                                self.assign_alternatives,
+                                                                                valid_combos,
+                                                                                self.apply_alternatives):
+            full_args = self.action_args + layer_args + arg_combo + assign_args + apply_args
+            with self.subTest(full_args=full_args):
+                parsed_args = self.parser.parse_args(full_args)
+                check_args(parsed_args)
+
+    def test_invalid_apply_args_not_saved_to_cfs(self):
+        """Test parsing with invalid apply args specified without saving to CFS"""
+        invalid_combos = [
+            self.base_config_args + self.save_to_file_args,
+            self.base_file_args + self.save_to_file_args,
+            self.base_file_args + self.save_args,
+            self.base_file_args + self.save_suffix_args
+        ]
+        expected_err_regex = (
+            'The options --clear-state, --clear-error, --enable, or --disable '
+            'require the resulting CFS configuration be saved to CFS.'
+        )
+
+        for layer_args, arg_combo, apply_args in itertools.product(self.layer_alternatives,
+                                                                   invalid_combos,
+                                                                   self.apply_alternatives):
+            full_args = self.action_args + layer_args + arg_combo + apply_args
+            with self.subTest(full_args=full_args):
+                parsed_args = self.parser.parse_args(full_args)
+                with self.assertRaisesRegex(ValueError, expected_err_regex):
+                    check_args(parsed_args)
+
+    def test_enable_disable_mutually_exclusive(self):
+        """Test parsing raises error when given mutually exclusive --enable/--disable options"""
+        full_args = (
+                self.action_args + self.product_layer_args + self.base_config_args +
+                self.save_args + self.enable_args + self.disable_args
+        )
+        self.assert_parse_error(full_args, 'argument --disable: not allowed with argument --enable')
 
 
 class TestCreatePassthroughParser(unittest.TestCase):
@@ -155,6 +337,7 @@ class TestCreatePassthroughParser(unittest.TestCase):
         self.mock_add_git_options = patch('cfs_config_util.parser.add_git_options').start()
         self.mock_add_base_options = patch('cfs_config_util.parser.add_base_options').start()
         self.mock_add_save_options = patch('cfs_config_util.parser.add_save_options').start()
+        self.mock_add_assign_options = patch('cfs_config_util.parser.add_assign_options').start()
 
     def tearDown(self):
         patch.stopall()
@@ -174,6 +357,7 @@ class TestCreatePassthroughParser(unittest.TestCase):
         )
         self.mock_add_base_options.assert_called_once_with(self.mock_argument_parser)
         self.mock_add_save_options.assert_called_once_with(self.mock_argument_parser)
+        self.mock_add_assign_options.assert_called_once_with(self.mock_argument_parser)
 
 
 if __name__ == '__main__':

--- a/tests/test_process_file_options.py
+++ b/tests/test_process_file_options.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -33,7 +33,7 @@ class TestProcessFileOptions(unittest.TestCase):
     """Test for the process_file_options function."""
 
     def setUp(self):
-        self.common_args = ['--product', 'sat', '--playbook', 'sat-ncn.yml']
+        self.common_args = ['update-config', '--product', 'sat', '--playbook', 'sat-ncn.yml']
         self.common_args_string = ' '.join(self.common_args)
         self.base_file_name = 'ncn-personalization.json'
         self.save_file_name = 'updated-ncn-personalization.json'

--- a/tests/test_update_configs.py
+++ b/tests/test_update_configs.py
@@ -1,0 +1,147 @@
+#
+# MIT License
+#
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+import unittest
+from argparse import Namespace
+from unittest.mock import patch, MagicMock
+
+from cfs_config_util.environment import API_GW_HOST
+from cfs_config_util.update_configs import construct_layers, save_cfs_configuration
+from csm_api_client.service.cfs import CFSConfiguration
+
+
+class TestConstructLayers(unittest.TestCase):
+    """Tests for the construct_layers() function"""
+
+    def setUp(self):
+        self.layer_name = 'test_layer'
+        self.playbook_name = 'test.yml'
+        self.product_name = 'product'
+
+        self.args = Namespace(
+            layer_name=self.layer_name,
+            playbooks=[self.playbook_name],
+            product=self.product_name,
+            git_commit=None,
+            git_branch=None,
+        )
+
+        patcher = patch('cfs_config_util.update_configs.CFSConfigurationLayer')
+        self.mock_cfs_configuration_layer = patcher.start()
+
+    def tearDown(self):
+        patch.stopall()
+
+    def test_single_layer_constructed(self):
+        """Test constructing a single layer for a product"""
+        construct_layers(self.args)
+        self.mock_cfs_configuration_layer.from_product_catalog.assert_called_once_with(
+            self.product_name,
+            API_GW_HOST,
+            product_version=None,
+            name=self.layer_name,
+            playbook=self.playbook_name,
+            commit=None,
+            branch=None,
+        )
+
+    def test_single_default_layer_constructed_for_no_playbook(self):
+        """Test that a default layer is constructed when no playbook is given"""
+        self.args.playbooks = None
+        construct_layers(self.args)
+        self.mock_cfs_configuration_layer.from_product_catalog.assert_called_once_with(
+            self.product_name,
+            API_GW_HOST,
+            product_version=None,
+            name=self.layer_name,
+            playbook=None,
+            commit=None,
+            branch=None,
+        )
+
+    def test_multiple_playbook_layers_constructed(self):
+        """Test constructing multiple layers for a product with multiple playbooks"""
+        additional_playbook = 'additional.yml'
+        playbooks = [self.playbook_name, additional_playbook]
+        self.args.playbooks = playbooks
+
+        construct_layers(self.args)
+
+        for playbook in playbooks:
+            self.mock_cfs_configuration_layer.from_product_catalog.assert_any_call(
+                self.product_name,
+                API_GW_HOST,
+                product_version=None,
+                name=self.layer_name,
+                playbook=playbook,
+                commit=None,
+                branch=None,
+            )
+
+
+class TestSaveCFSConfigs(unittest.TestCase):
+    """Tests for the save_cfs_configurations() function"""
+    def setUp(self):
+        self.product_name = 'testproduct'
+        self.config_name = 'test-config'
+        self.config_path = 'test_config.json'
+
+        self.base_args = Namespace(
+            product=self.product_name,
+            base_config=None,
+            base_file=None,
+            base_query=None,
+            save=None,
+            save_suffix=None,
+            save_to_file=None,
+            save_to_cfs=None,
+            create_backups=None
+        )
+
+        self.mock_cfs_config = MagicMock(autospec=CFSConfiguration)
+
+    def tearDown(self):
+        patch.stopall()
+
+    def test_save_to_cfs_no_overwrite_when_no_base(self):
+        """Test that overwriting CFS config is disabled when no base is given"""
+        self.base_args.save_to_cfs = self.config_name
+
+        save_cfs_configuration(self.base_args, self.mock_cfs_config)
+        self.mock_cfs_config.save_to_cfs.assert_called_once_with(
+            self.config_name,
+            overwrite=False,
+            backup_suffix=None
+        )
+
+    def test_save_to_file_no_overwrite_when_no_base(self):
+        """Test that overwriting file is disabled when no base is given"""
+        self.base_args.save_to_file = self.config_path
+
+        save_cfs_configuration(self.base_args, self.mock_cfs_config)
+        self.mock_cfs_config.save_to_file.assert_called_once_with(
+            self.config_path,
+            overwrite=False,
+            backup_suffix=None
+        )


### PR DESCRIPTION
* CASMINST-6597: Update version of `csm-api-client`

  This branch needs new functionality introduced in version 1.2.0 of the
  `csm-api-client` Python package.

* CASMINST-6597: Add changelog entry and declare version 5.0.0

  This is a major version bump because it breaks backwards compatibility
  since the `cfs-config-util` CLI now requires an action argument of
  either `update-config` or `update-components`.

* CASMINST-6597: Add component update options to cfs-config-util

  Add options to `cfs-config-util` to support modifying CFS components in
  addition to modifying CFS configurations. This splits the main
  `cfs-config-util` entry point into two different actions:
  `update-configs` and `update-components`.

  The `update-configs` action allows for the updating of a CFS
  configuration, which includes adding and removing a layer or layers for
  a product. This action is what the main entry point used to do, but with
  some additional options added. These additional options add support for
  backing up CFS configurations when they are overwritten, assigning a CFS
  configuration to components after modification, making additional
  changes to the impacted CFS components, and waiting on the CFS
  components to become configured by the CFS Batcher.

  The `update-components` action allows for updating CFS components and
  waiting for them to reach a configured state. This is useful when you
  need to update the configuration assigned to a component as its
  `desiredConfig` or clear the error count or state of a component, but
  you don't need to update the CFS configuration contents itself.

  Note that because the main entry point now requires an action, this
  change is backwards incompatible. If we want to update the other users
  of this command (scripts in the SAT and COS product streams), we would
  just need to update the call to include the `update-configs` action as
  the first argument.

  Test Description:
  Built against the new `csm-api-client` Python package and executed the
  container with `podman` on mug with various options to modify CFS
  configurations and update CFS components.

  New unit tests pass.

## Risks and Mitigations

This is a backwards-incompatible change to the main entry point of the cfs-config-util. The only known users of this utility are the SAT and COS product streams. The major version of this library is being updated to reflect this major change. The SAT and COS product streams can update to this version when ready, and doing so just involves adding the argument `update-configs` to the scripts which call `cfs-config-util`, which is an easy change.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
