### PR TITLE
CRAYSAT-1880 : Resolve dependabot alerts for requests and urllib3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [5.0.2] - 2024-07-05
+
+### Security
+- Update requests from 2.31.0 to 2.32.0 to address CVE-2024-35195.
+- Update urllib3 from 1.26.18 to 1.26.19 to address CVE-2024-37891.
+
 # [5.0.1] - 2024-05-06
 
 ### Security

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -22,7 +22,7 @@ pydantic==1.10.13
 pyrsistent==0.18.1
 python-dateutil==2.8.2
 PyYAML==6.0.1
-requests==2.31.0
+requests==2.32.0
 requests-oauthlib==1.3.1
 rsa==4.9
 s3transfer==0.6.0

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -28,5 +28,5 @@ rsa==4.9
 s3transfer==0.6.0
 six==1.16.0
 typing_extensions==4.3.0
-urllib3==1.26.18
+urllib3==1.26.19
 websocket-client==1.4.1

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -25,5 +25,5 @@ rsa==4.9
 s3transfer==0.6.0
 six==1.16.0
 typing_extensions==4.3.0
-urllib3==1.26.18
+urllib3==1.26.19
 websocket-client==1.4.1

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -19,7 +19,7 @@ pydantic==1.10.13
 pyrsistent==0.18.1
 python-dateutil==2.8.2
 PyYAML==6.0.1
-requests==2.31.0
+requests==2.32.0
 requests-oauthlib==1.3.1
 rsa==4.9
 s3transfer==0.6.0


### PR DESCRIPTION
## Summary and Scope

_Combines https://github.com/Cray-HPE/cfs-config-util/pull/29, https://github.com/Cray-HPE/cfs-config-util/pull/30 from dependabot into a single PR with a changelog update._

## Issues and Related PRs

_Resolves 2 dependabot alerts in [CRAYSAT-1880](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1880)._


## Testing

_List the environments in which these changes were tested._

### Tested on:

_Baldar_

### Test description:

_Tested by update-config with querying Management node and saved with save-suffix
`cfs-config-util update-configs --base-query role=Management --save-suffix .annapoorna --product sat --playbook sat-ncn.yml`_

## Risks and Mitigations

_Low_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

