### PR TITLE
CRAYSAT-1842: Add support for the CFS v3 API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# [5.1.0] - 2024-08-29
+# [5.1.0] - 2024-08-20
+
+### Added
+- Added support for CFS v3 API. The CFS API version can be specified with the
+  new `--cfs-version` option, which defaults to `v3`.
+- Added a new `--verbose` command-line option which enables debug logging in
+  `cfs-config-util`.
+
+### Fixed
+- Fixed bug where `additional_inventory` was dropped from CFS configurations
+  when modified by `cfs-config-util`.
+- Fixed bug where `specialParameters.imsRequireDkms` (CFS v2) or
+  `special_parameters.ims_require_dkms` (CFS v3) was dropped from CFS
+  configurations when modified by `cfs-config-util`.
+
+# [5.0.4] - 2024-08-29
 
 ### Changed
 - Update cray-product-catalog to latest version 2.3.1

--- a/cfs_config_util/bin/main.py
+++ b/cfs_config_util/bin/main.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -31,7 +31,7 @@ from cfs_config_util.parser import (
     CANONICAL_UPDATE_CONFIGS_ACTION,
     CANONICAL_UPDATE_COMPONENTS_ACTION,
     check_args,
-    create_parser,
+    create_parser
 )
 from cfs_config_util.update_components import do_update_components
 from cfs_config_util.update_configs import do_update_configs
@@ -39,7 +39,7 @@ from cfs_config_util.update_configs import do_update_configs
 LOGGER = logging.getLogger(__name__)
 
 
-def configure_logging():
+def configure_logging(verbose=False):
     """Configure logging for the cfs-config-util executable.
 
     This sets up the root logger with the default format, INFO log level, and
@@ -48,14 +48,30 @@ def configure_logging():
     Returns:
         None.
     """
+    level = logging.DEBUG if verbose else logging.INFO
     console_log_format = '%(levelname)s: %(message)s'
     logger = logging.getLogger()
     console_handler = logging.StreamHandler()
-    console_handler.setLevel(logging.INFO)
+    console_handler.setLevel(level)
     console_formatter = logging.Formatter(console_log_format)
     console_handler.setFormatter(console_formatter)
     logger.addHandler(console_handler)
-    logger.setLevel(logging.INFO)
+    logger.setLevel(level)
+
+
+def log_args_and_exit(args):
+    from enum import Enum
+    import json
+
+    # Make the args.state value JSON serializable
+    class CustomEncoder(json.JSONEncoder):
+        def default(self, o):
+            if isinstance(o, Enum):
+                return o.value
+            return super().default(o)
+
+    LOGGER.debug(json.dumps(vars(args), cls=CustomEncoder, indent=4))
+    raise SystemExit(0)
 
 
 def main():
@@ -67,10 +83,11 @@ def main():
     Raises:
         SystemExit: if there is a failure to get the base config, modify it, or save it
     """
-    configure_logging()
-
     parser = create_parser()
     args = parser.parse_args()
+    configure_logging(verbose=args.verbose)
+    log_args_and_exit(args)
+
     try:
         check_args(args)
     except ValueError as err:

--- a/cfs_config_util/bin/main.py
+++ b/cfs_config_util/bin/main.py
@@ -59,21 +59,6 @@ def configure_logging(verbose=False):
     logger.setLevel(level)
 
 
-def log_args_and_exit(args):
-    from enum import Enum
-    import json
-
-    # Make the args.state value JSON serializable
-    class CustomEncoder(json.JSONEncoder):
-        def default(self, o):
-            if isinstance(o, Enum):
-                return o.value
-            return super().default(o)
-
-    LOGGER.debug(json.dumps(vars(args), cls=CustomEncoder, indent=4))
-    raise SystemExit(0)
-
-
 def main():
     """Modify a CFS configuration and save it as specified by the command-line args.
 
@@ -86,7 +71,6 @@ def main():
     parser = create_parser()
     args = parser.parse_args()
     configure_logging(verbose=args.verbose)
-    log_args_and_exit(args)
 
     try:
         check_args(args)

--- a/cfs_config_util/bin/process_file_options.py
+++ b/cfs_config_util/bin/process_file_options.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -38,7 +38,7 @@ import json
 import os
 import sys
 
-from cfs_config_util.parser import create_parser, BASE_FILE_OPTION, SAVE_TO_FILE_OPTION
+from cfs_config_util.parser import BASE_FILE_OPTION, SAVE_TO_FILE_OPTION, create_parser
 
 DATA_DIR = '/data/'
 INPUT_DATA_DIR = os.path.join(DATA_DIR, 'input')

--- a/cfs_config_util/parser.py
+++ b/cfs_config_util/parser.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -106,6 +106,23 @@ def convert_query_to_dict(query_str):
     return dict(params)
 
 
+def add_global_options(parser):
+    """Add global options to the top-level parser.
+
+    Args:
+        parser (argparse.ArgumentParser): the parser to which options are added
+    """
+    global_group = parser.add_argument_group('Global Options')
+    global_group.add_argument(
+        '--verbose', '-v', action='store_true',
+        help='Enable debug logging.'
+    )
+    global_group.add_argument(
+        '--cfs-version', choices=['v2', 'v3'], default='v3',
+        help='The version of the CFS API to use. Defaults to v3.'
+    )
+
+
 def add_git_options(group):
     """Add options which control which git ref is used in a layer.
 
@@ -149,7 +166,7 @@ def add_layer_content_options(parser):
     Returns: None
     """
     repo_group = parser.add_argument_group(
-        title='VCS Repo Options',
+        title='Layer Content Options',
         description='Options that control the content of the layer to be added '
                     'or removed.'
     )
@@ -483,6 +500,7 @@ def create_passthrough_parser():
     """
     parser = argparse.ArgumentParser(add_help=False, usage=argparse.SUPPRESS, allow_abbrev=False)
 
+    add_global_options(parser)
     # Add subset of the options added by add_layer_content_options
     git_group = parser.add_argument_group(
         title='Git Options',
@@ -575,6 +593,7 @@ def create_parser():
     """
     parser = argparse.ArgumentParser(allow_abbrev=False)
 
+    add_global_options(parser)
     subparsers = parser.add_subparsers(metavar='action', dest='action')
     add_update_configs_subparser(subparsers)
     add_update_components_subparser(subparsers)

--- a/cfs_config_util/update_components.py
+++ b/cfs_config_util/update_components.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -34,9 +34,7 @@ from cfs_config_util.errors import CFSConfigUtilError
 from cfs_config_util.hsm import get_node_ids
 from cfs_config_util.wait import wait_for_component_configuration
 
-from csm_api_client.service.cfs import (
-    CFSClient
-)
+from csm_api_client.service.cfs import CFSClientBase
 from csm_api_client.service.gateway import APIError
 from csm_api_client.service.hsm import HSMClient
 from csm_api_client.session import AdminSession
@@ -49,7 +47,7 @@ def update_cfs_components(cfs_client, component_ids, desired_config=None, clear_
     """Assign the CFSConfiguration to the given CFS components.
 
     Args:
-        cfs_client (csm_api_client.service.cfs.CFSClient): the CFS API client
+        cfs_client (csm_api_client.service.cfs.CFSClientBase): the CFS API client
         component_ids (Iterable): the list of component ids (xnames) to update
         desired_config (str, Optional): the name of the desired config to set
             on the components, if any
@@ -89,7 +87,7 @@ def do_update_components(args):
     """
     session = AdminSession(API_GW_HOST, API_CERT_VERIFY)
     hsm_client = HSMClient(session)
-    cfs_client = CFSClient(session)
+    cfs_client = CFSClientBase.get_cfs_client(session, args.cfs_version)
 
     component_ids = get_node_ids(hsm_client, component_ids=args.xnames,
                                  hsm_query=args.query)

--- a/cfs_config_util/update_configs.py
+++ b/cfs_config_util/update_configs.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -30,8 +30,7 @@ import json
 import logging
 
 from csm_api_client.service.cfs import (
-    CFSClient,
-    CFSConfiguration,
+    CFSClientBase,
     CFSConfigurationError,
     CFSConfigurationLayer
 )
@@ -61,11 +60,11 @@ def get_cfs_configurations(args, cfs_client, hsm_client):
 
     Args:
         args (argparse.Namespace): the parsed command-line args
-        cfs_client (csm_api_client.service.cfs.CFSClient): the CFS API client
+        cfs_client (csm_api_client.service.cfs.CFSClientBase): the CFS API client
         hsm_client (cfs_config_util.apiclient.HSMClient): the HSM API client
 
     Returns:
-        list of csm_api_client.service.cfs.CFSConfiguration: the CFS configurations
+        list of csm_api_client.service.cfs.CFSConfigurationBase: the CFS configurations
             from CFS or loaded from a file. If a name of a CFS config or a file
             name is given, the list will have only one element.
 
@@ -74,7 +73,7 @@ def get_cfs_configurations(args, cfs_client, hsm_client):
             API or unable to load it from a file
     """
     if args.base_config is not None:
-        # Get the CFSConfiguration from the CFS API
+        # Get the CFS configuration from the CFS API
         try:
             return [cfs_client.get_configuration(args.base_config)]
         except APIError as err:
@@ -109,11 +108,11 @@ def get_cfs_configurations(args, cfs_client, hsm_client):
         except json.decoder.JSONDecodeError as err:
             raise CFSConfigurationError(f'Failed to parse JSON in file {args.base_file}: {err}')
 
-        return [CFSConfiguration(cfs_client, file_data)]
+        return [cfs_client.configuration_cls(cfs_client, file_data)]
 
 
 def construct_layers(args):
-    """Construct CFSConfigurationLayer(s) which should be added or removed from a CFSConfiguration.
+    """Construct CFSConfigurationLayer(s) which should be added or removed from a CFSConfigurationBase.
 
     Args:
         args (argparse.Namespace): the parsed command-line args
@@ -160,16 +159,16 @@ def construct_layers(args):
 
 
 def save_cfs_configuration(args, cfs_config):
-    """Save the CFSConfiguration to a file or to CFS per the command-line args.
+    """Save the CFSConfigurationBase to a file or to CFS per the command-line args.
 
     Args:
         args (argparse.Namespace): the parsed command-line args
-        cfs_config (csm_api_client.service.cfs.CFSConfiguration): the modified
+        cfs_config (csm_api_client.service.cfs.CFSConfigurationBase): the modified
             CFS configuration to save
 
     Returns:
-        CFSConfiguration or None: if a new CFS configuration was saved to CFS,
-            return the new CFSConfiguration object.
+        CFSConfigurationBase or None: if a new CFS configuration was saved to CFS,
+            return the new CFSConfigurationBase object.
 
     Raises:
         CFSConfigurationError: if unable to save the CFS configuration to CFS
@@ -208,8 +207,8 @@ def get_affected_components(cfs_client, cfs_configs):
     """Get CFS components which have one of the configs as their desiredConfig.
 
     Args:
-        cfs_client (csm_api_client.service.cfs.CFSClient): the CFS API client
-        cfs_configs (csm_api_client.service.cfs.CFSConfiguration): the CFS
+        cfs_client (csm_api_client.service.cfs.CFSClientBase): the CFS API client
+        cfs_configs (csm_api_client.service.cfs.CFSConfigurationBase): the CFS
             configurations to check
 
     Returns:
@@ -234,11 +233,11 @@ def update_configurations(args, cfs_client, hsm_client):
 
     Args:
         args (argparse.Namespace): the parsed command-line arguments
-        cfs_client (csm_api_client.service.cfs.CFSClient): the CFS API client
+        cfs_client (csm_api_client.service.cfs.CFSClientBase): the CFS API client
         hsm_client (csm_api_client.service.hsm.HSMClient): the HSM API client
 
     Returns:
-        A tuple consisting of the CFSConfiguration objects which have been
+        A tuple consisting of the CFSConfigurationBase objects which have been
         updated and those which did not need to be updated.
     """
     try:
@@ -247,7 +246,7 @@ def update_configurations(args, cfs_client, hsm_client):
         else:
             LOGGER.info('No base configuration given. Starting from empty configuration. '
                         'Existing configurations will not be overwritten.')
-            base_configs = [CFSConfiguration.empty(cfs_client)]
+            base_configs = [cfs_client.configuration_cls.empty(cfs_client)]
 
         layers = construct_layers(args)
 
@@ -297,7 +296,7 @@ def assign_configuration(args, cfs_client, hsm_client, cfs_config_name):
 
     Args:
         args (argparse.Namespace): the parsed command-line arguments
-        cfs_client (csm_api_client.service.cfs.CFSClient): the CFS API client
+        cfs_client (csm_api_client.service.cfs.CFSClientBase): the CFS API client
         hsm_client (csm_api_client.service.hsm.HSMClient): the HSM API client
         cfs_config_name (str): CFS configuration name to assign to components
 
@@ -332,7 +331,7 @@ def do_update_configs(args):
     """
     session = AdminSession(API_GW_HOST, API_CERT_VERIFY)
     hsm_client = HSMClient(session)
-    cfs_client = CFSClient(session)
+    cfs_client = CFSClientBase.get_cfs_client(session, args.cfs_version)
 
     modified_configs, unmodified_configs = update_configurations(args, cfs_client, hsm_client)
 

--- a/cfs_config_util/update_configs.py
+++ b/cfs_config_util/update_configs.py
@@ -32,6 +32,8 @@ import logging
 from csm_api_client.service.cfs import (
     CFSClientBase,
     CFSConfigurationError,
+    CFSV2ConfigurationLayer,
+    CFSV3ConfigurationLayer,
     CFSConfigurationLayer
 )
 from csm_api_client.service.gateway import APIError
@@ -329,6 +331,14 @@ def do_update_configs(args):
     Args:
         args (argparse.Namespace): the parsed command-line arguments
     """
+
+    global CFSConfigurationLayer
+    cfs_version = args.cfs_version
+    if cfs_version == 'v3':
+        CFSConfigurationLayer = CFSV3ConfigurationLayer
+    else:  # Default to v2 if version is not recognized
+        CFSConfigurationLayer = CFSV2ConfigurationLayer
+
     session = AdminSession(API_GW_HOST, API_CERT_VERIFY)
     hsm_client = HSMClient(session)
     cfs_client = CFSClientBase.get_cfs_client(session, args.cfs_version)

--- a/cfs_config_util/wait.py
+++ b/cfs_config_util/wait.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -38,7 +38,7 @@ def get_components_by_status(cfs_client, component_ids):
     """Get a dict mapping component state to a list of components in that state.
 
     Args:
-        cfs_client (csm_api_client.service.cfs.CFSClient): the CFS API client
+        cfs_client (csm_api_client.service.cfs.CFSClientBase): the CFS API client
         component_ids (Iterable): the component IDs to query
 
     Returns:
@@ -52,6 +52,8 @@ def get_components_by_status(cfs_client, component_ids):
     disabled_components = set()
     error_components = set()
     components_by_status = defaultdict(set)
+    config_status_key = cfs_client.join_words('configuration', 'status')
+
     for component_id in component_ids:
         try:
             component_data = cfs_client.get('components', component_id).json()
@@ -60,7 +62,7 @@ def get_components_by_status(cfs_client, component_ids):
             error_components.add(component_id)
         else:
             if component_data['enabled']:
-                components_by_status[component_data['configurationStatus']].add(component_id)
+                components_by_status[component_data[config_status_key]].add(component_id)
             else:
                 disabled_components.add(component_id)
 
@@ -83,7 +85,7 @@ def wait_for_component_configuration(cfs_client, wait_component_ids, check_inter
     and reached either "configured" or "failed" states.
 
     Args:
-        cfs_client (csm_api_client.service.cfs.CFSClient): the CFS API client
+        cfs_client (csm_api_client.service.cfs.CFSClientBase): the CFS API client
         wait_component_ids (Iterable): the component IDs to wait on
         check_interval (int): the number of seconds to wait between checks on
             component state

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -6,7 +6,7 @@ certifi==2024.7.4
 charset-normalizer==2.1.1
 coverage==6.0.2
 cray-product-catalog==2.3.1
-csm-api-client==2.2.0
+csm-api-client==2.2.1
 google-auth==2.11.0
 idna==3.7
 inflect==6.0.0

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -6,7 +6,7 @@ certifi==2024.7.4
 charset-normalizer==2.1.1
 coverage==6.0.2
 cray-product-catalog==2.3.1
-csm-api-client==2.1.0
+csm-api-client==2.2.0
 google-auth==2.11.0
 idna==3.7
 inflect==6.0.0
@@ -26,6 +26,7 @@ requests==2.32.0
 requests-oauthlib==1.3.1
 rsa==4.9
 s3transfer==0.6.0
+semver==3.0.2
 six==1.16.0
 typing_extensions==4.3.0
 urllib3==1.26.19

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -5,7 +5,7 @@ cachetools==5.2.0
 certifi==2024.7.4
 charset-normalizer==2.1.1
 cray-product-catalog==2.3.1
-csm-api-client==2.2.0
+csm-api-client==2.2.1
 google-auth==2.11.0
 idna==3.7
 inflect==6.0.0

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -5,7 +5,7 @@ cachetools==5.2.0
 certifi==2024.7.4
 charset-normalizer==2.1.1
 cray-product-catalog==2.3.1
-csm-api-client==2.1.0
+csm-api-client==2.2.0
 google-auth==2.11.0
 idna==3.7
 inflect==6.0.0
@@ -23,6 +23,7 @@ requests==2.32.0
 requests-oauthlib==1.3.1
 rsa==4.9
 s3transfer==0.6.0
+semver==3.0.2
 six==1.16.0
 typing_extensions==4.3.0
 urllib3==1.26.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 cray-product-catalog >= 2.3.1
-csm-api-client >= 2.2, < 3.0
+csm-api-client >= 2.2.1, < 3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 cray-product-catalog >= 2.3.1
-csm-api-client >= 2.1.0
+csm-api-client >= 2.2, < 3.0

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -132,7 +132,7 @@ class TestEnsureProductLayer(unittest.TestCase):
         self.mock_cfs_config_layer = self.mock_cfs_config_layer_cls.from_product_catalog.return_value
         self.mock_admin_session = patch('cfs_config_util.activation.AdminSession').start()
         self.mock_hsm_client = patch('cfs_config_util.activation.HSMClient').start().return_value
-        self.mock_cfs_client = patch('cfs_config_util.activation.CFSClient').start().return_value
+        self.mock_cfs_client = patch('cfs_config_util.activation.CFSClientBase.get_cfs_client').start().return_value
 
         self.mock_cfs_config_names = ['ncn-personalization', 'ncn-personalization-storage']
         self.mock_cfs_configs = []

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -63,7 +63,7 @@ class TestActivateDeactivate(unittest.TestCase):
         self.assertEqual(self.mock_ensure_product_layer.return_value, ret_val)
         self.mock_ensure_product_layer.assert_called_once_with(
             self.product, self.version, self.playbook, LayerState.PRESENT, self.hsm_query_params,
-            None, None
+            None, None, 'v3'
         )
 
     def test_cfs_activate_version_git_commit(self):
@@ -73,7 +73,7 @@ class TestActivateDeactivate(unittest.TestCase):
         self.assertEqual(self.mock_ensure_product_layer.return_value, ret_val)
         self.mock_ensure_product_layer.assert_called_once_with(
             self.product, self.version, self.playbook, LayerState.PRESENT, self.hsm_query_params,
-            self.git_commit, None
+            self.git_commit, None, 'v3'
         )
 
     def test_cfs_activate_version_git_branch(self):
@@ -83,7 +83,7 @@ class TestActivateDeactivate(unittest.TestCase):
         self.assertEqual(self.mock_ensure_product_layer.return_value, ret_val)
         self.mock_ensure_product_layer.assert_called_once_with(
             self.product, self.version, self.playbook, LayerState.PRESENT, self.hsm_query_params,
-            None, self.git_branch
+            None, self.git_branch, 'v3'
         )
 
     def test_cfs_deactivate_version_no_git_ref(self):
@@ -92,7 +92,7 @@ class TestActivateDeactivate(unittest.TestCase):
         self.assertEqual(self.mock_ensure_product_layer.return_value, ret_val)
         self.mock_ensure_product_layer.assert_called_once_with(
             self.product, self.version, self.playbook, LayerState.ABSENT, self.hsm_query_params,
-            None, None
+            None, None, 'v3'
         )
 
     def test_cfs_deactivate_version_git_commit(self):
@@ -102,7 +102,7 @@ class TestActivateDeactivate(unittest.TestCase):
         self.assertEqual(self.mock_ensure_product_layer.return_value, ret_val)
         self.mock_ensure_product_layer.assert_called_once_with(
             self.product, self.version, self.playbook, LayerState.ABSENT, self.hsm_query_params,
-            self.git_commit, None
+            self.git_commit, None, 'v3'
         )
 
     def test_cfs_deactivate_version_git_branch(self):
@@ -112,7 +112,7 @@ class TestActivateDeactivate(unittest.TestCase):
         self.assertEqual(self.mock_ensure_product_layer.return_value, ret_val)
         self.mock_ensure_product_layer.assert_called_once_with(
             self.product, self.version, self.playbook, LayerState.ABSENT, self.hsm_query_params,
-            None, self.git_branch
+            None, self.git_branch, 'v3'
         )
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -349,7 +349,10 @@ class TestCreatePassthroughParser(unittest.TestCase):
         self.mock_argument_parser_cls.assert_called_once_with(add_help=False,
                                                               usage=argparse.SUPPRESS,
                                                               allow_abbrev=False)
-        self.mock_argument_parser.add_argument_group.assert_called_once_with(
+
+        self.assertEqual(self.mock_argument_parser.add_argument_group.call_count, 2)
+        self.mock_argument_parser.add_argument_group.assert_any_call('Global Options')
+        self.mock_argument_parser.add_argument_group.assert_any_call(
             title='Git Options', description='Options that control the git ref used in the layer.'
         )
         self.mock_add_git_options.assert_called_once_with(


### PR DESCRIPTION
## Summary and Scope

Add support for the CFS v3 API. This pulls in a new version of the
csm-api-client library that adds support for CFS v3 while still
supporting CFS v2. The user of `cfs-config-util` can specify the CFS API
version using the new `--cfs-version` option.

This newer version of the library also fixes bugs with the handling of
CFS configurations that have specified `additional_inventory` and the
value `special_parameters.ims_require_dkms`. Older versions would drop
`additional_inventory` and `ims_require_dkms` when modifying it. This
will no longer occur with the newer version of `csm_api_client`.

Improve option handling in `cfs-config-util` so that global options can
be specified either before or after the subcommand. This includes the
`--cfs-version` as well as a new `--verbose` option. The `--verbose`
option provides a way to enable debug logging which will potentially be
useful when debugging changes to this script.

## Issues and Related PRs

* Resolves CRAYSAT-1842

## Testing

### Tested on:

### Test description:

Not tested yet.

## Risks and Mitigations

This does make significant changes to the underlying dependency `csm-api-client`, but it's necessary to fix major bugs in the handling of CFS configurations and to migrate to CFS v3.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
