### PR TITLE
CRAYSAT-1897: Backport the changes from 5.0.0 to 5.0.3 

### DIFF
--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -41,7 +41,7 @@ jobs:
 
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v35
+      uses: tj-actions/changed-files@v41
 
     - name: License Check
       if: ${{ steps.changed-files.outputs.all_changed_files }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [5.0.3] - 2024-07-09
+
+### Security
+- Update certifi from 2023.7.22 to 2024.7.4 to address CVE-2024-39689.
+
 # [5.0.2] - 2024-07-05
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [5.0.2] - 2024-07-05
+
+### Security
+- Update requests from 2.31.0 to 2.32.0 to address CVE-2024-35195.
+- Update urllib3 from 1.26.18 to 1.26.19 to address CVE-2024-37891.
+
 # [5.0.1] - 2024-05-06
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-(C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+(C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -24,6 +24,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+# [5.0.1] - 2024-05-06
+
+### Security
+- Update idna from 3.4 to 3.7 to address CVE-2024-3651.
+- Update pydantic from 1.10.2 to 1.10.13 to address CVE-2024-3772.
+- Update urllib3 from 1.26.12 to 1.26.18 to address CVE-2023-45803.
 
 ## [5.0.0] - 2023-09-14
 

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -2,7 +2,7 @@ attrs==22.1.0
 boto3==1.24.74
 botocore==1.27.74
 cachetools==5.2.0
-certifi==2023.7.22
+certifi==2024.7.4
 charset-normalizer==2.1.1
 coverage==6.0.2
 cray-product-catalog==1.8.12

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -22,11 +22,11 @@ pydantic==1.10.13
 pyrsistent==0.18.1
 python-dateutil==2.8.2
 PyYAML==6.0.1
-requests==2.31.0
+requests==2.32.0
 requests-oauthlib==1.3.1
 rsa==4.9
 s3transfer==0.6.0
 six==1.16.0
 typing_extensions==4.3.0
-urllib3==1.26.18
+urllib3==1.26.19
 websocket-client==1.4.1

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -8,7 +8,7 @@ coverage==6.0.2
 cray-product-catalog==1.8.12
 csm-api-client==1.2.0
 google-auth==2.11.0
-idna==3.4
+idna==3.7
 inflect==6.0.0
 jmespath==1.0.1
 jsonschema==4.16.0
@@ -18,7 +18,7 @@ oauthlib==3.2.2
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pycodestyle==2.8.0
-pydantic==1.10.2
+pydantic==1.10.13
 pyrsistent==0.18.1
 python-dateutil==2.8.2
 PyYAML==6.0.1
@@ -28,5 +28,5 @@ rsa==4.9
 s3transfer==0.6.0
 six==1.16.0
 typing_extensions==4.3.0
-urllib3==1.26.12
+urllib3==1.26.18
 websocket-client==1.4.1

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -2,7 +2,7 @@ attrs==22.1.0
 boto3==1.24.74
 botocore==1.27.74
 cachetools==5.2.0
-certifi==2023.7.22
+certifi==2024.7.4
 charset-normalizer==2.1.1
 cray-product-catalog==1.8.12
 csm-api-client==1.2.0

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -7,7 +7,7 @@ charset-normalizer==2.1.1
 cray-product-catalog==1.8.12
 csm-api-client==1.2.0
 google-auth==2.11.0
-idna==3.4
+idna==3.7
 inflect==6.0.0
 jmespath==1.0.1
 jsonschema==4.16.0
@@ -15,7 +15,7 @@ kubernetes==23.6.0
 oauthlib==3.2.2
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
-pydantic==1.10.2
+pydantic==1.10.13
 pyrsistent==0.18.1
 python-dateutil==2.8.2
 PyYAML==6.0.1
@@ -25,5 +25,5 @@ rsa==4.9
 s3transfer==0.6.0
 six==1.16.0
 typing_extensions==4.3.0
-urllib3==1.26.12
+urllib3==1.26.18
 websocket-client==1.4.1

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -19,11 +19,11 @@ pydantic==1.10.13
 pyrsistent==0.18.1
 python-dateutil==2.8.2
 PyYAML==6.0.1
-requests==2.31.0
+requests==2.32.0
 requests-oauthlib==1.3.1
 rsa==4.9
 s3transfer==0.6.0
 six==1.16.0
 typing_extensions==4.3.0
-urllib3==1.26.18
+urllib3==1.26.19
 websocket-client==1.4.1


### PR DESCRIPTION
## Summary and Scope

_Backport the changes from 5.0.0 to 5.0.3 in cfs-config-util repository_

## Issues and Related PRs

_This includes the following fixes._

* https://github.com/Cray-HPE/cfs-config-util/pull/28
* https://github.com/Cray-HPE/cfs-config-util/pull/31
* https://github.com/Cray-HPE/cfs-config-util/pull/32

## Testing

  See the linked PRs

## Risks and Mitigations

  See the linked PRs


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

