### PR TITLE
CRAYSAT-1919: Fix 5.1.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,8 +46,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `special_parameters.ims_require_dkms` (CFS v3) was dropped from CFS
   configurations when modified by `cfs-config-util`.
 
-## [5.0.4] - 2024-08-29
-
 ### Changed
 - Update cray-product-catalog to latest version 2.3.1
 - Update csm-api-client to latest version 2.1.0


### PR DESCRIPTION
## Summary and Scope

Move the updates of cray-product-catalog and csm-api-client dependencies into 5.1.0 release of cfs-config-util. These are pretty significant changes, so it makes sense to include them in the minor version bump rather than a patch bump. This also simplifies backporting the other versioning changes that need to be made to the release/5.0 branch.

I'm only changing the already published versions because the build versions got messed up on artifactory anyway, and I'm going to be creating a new 5.0.3 and 5.1.0 build to fix that.

## Issues and Related PRs

* Required by CRAYSAT-1919

## Testing

### Tested on:

  * Local development environment


### Test description:

Checked that `version.sh` still printed 5.1.0 for the version from the changelog.

## Risks and Mitigations

Low risk as version 5.1.0 was never properly published, and this actually reduces risk by pulling changes out of the 5.0 release.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable